### PR TITLE
Refine inventory table layout and add notes popup

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -742,32 +742,6 @@ th:nth-child(15) { width: 50px; }  /* Delete */
   outline-offset: 1px;
 }
 
-/* Delete cell styling */
-.delete-cell {
-  text-align: center;
-  vertical-align: middle;
-}
-
-.delete-cell .btn {
-  margin: 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 24px;
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  font-size: 0.9rem;
-  font-weight: bold;
-  border-radius: 50%;
-  transition: all 0.2s;
-}
-
-.delete-cell .btn:hover {
-  transform: scale(1.1);
-  box-shadow: var(--shadow);
-}
-
 /* Make buttons in table cells smaller */
 td .btn {
   padding: 0.25rem 0.5rem;

--- a/index.html
+++ b/index.html
@@ -500,14 +500,14 @@
 <th>Type</th>
 <th>Name</th>
 <th>Weight (oz)</th>
-<th>Purchase Price ($)</th>
-<th>Spot Price ($/oz)</th>
-<th>Premium Paid ($/oz)</th>
+<th>Purchase Price at Purchase ($)</th>
+<th>Spot Price at Purchase ($/oz)</th>
 <th>Total Premium Paid ($)</th>
 <th>Purchase Location</th>
 <th>Storage Location</th>
 <th>Date</th>
 <th>Collectable</th>
+<th>Notes</th>
 <th>Delete</th>
 </tr>
 </thead>

--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
 <th>Type</th>
 <th>Name</th>
 <th>Weight (oz)</th>
-<th>Purchase Price at Purchase ($)</th>
+<th>Purchase Price ($)</th>
 <th>Spot Price at Purchase ($/oz)</th>
 <th>Total Premium Paid ($)</th>
 <th>Purchase Location</th>

--- a/js/events.js
+++ b/js/events.js
@@ -185,8 +185,8 @@ const setupEventListeners = () => {
     if (inventoryTable) {
       const headers = inventoryTable.querySelectorAll('th');
       headers.forEach((header, index) => {
-        // Skip # column (0) and Delete column (last column)
-        if (index === 0 || index >= headers.length - 1) {
+        // Skip # column (0) and Notes/Delete columns (last two)
+        if (index === 0 || index >= headers.length - 2) {
           return;
         }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -443,7 +443,6 @@ const renderTable = () => {
       <td>${parseFloat(item.weight).toFixed(2)}</td>
       <td>${formatDollar(item.price)}</td>
       <td>${item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatDollar(item.spotPriceAtPurchase) : 'N/A')}</td>
-      <td style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.premiumPerOz > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.premiumPerOz)}</td>
       <td style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.totalPremium)}</td>
       <td>${sanitizeHtml(item.purchaseLocation)}</td>
       <td>${sanitizeHtml(item.storageLocation || 'Unknown')}</td>
@@ -451,6 +450,7 @@ const renderTable = () => {
       <td class="checkbox-cell">
       <input type="checkbox" ${item.isCollectable ? 'checked' : ''} onchange="toggleCollectable(${originalIdx}, this)" class="collectable-checkbox" aria-label="Mark ${sanitizeHtml(item.name)} as collectable" title="Mark as collectable">
       </td>
+      <td><button class="btn" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
       <td class="delete-cell"><button class="btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item">&times;</button></td>
       </tr>
       `);
@@ -690,8 +690,18 @@ const deleteItem = (idx) => {
 };
 
 /**
+ * Displays the notes for an inventory item in a popup prompt
+ *
+ * @param {number} idx - Index of item whose notes to show
+ */
+const showNotes = (idx) => {
+  const item = inventory[idx];
+  window.prompt('Item Notes', item.notes || '');
+};
+
+/**
  * Prepares and displays edit modal for specified inventory item
- * 
+ *
  * @param {number} idx - Index of item to edit
  */
 const editItem = (idx) => {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -451,7 +451,7 @@ const renderTable = () => {
       <input type="checkbox" ${item.isCollectable ? 'checked' : ''} onchange="toggleCollectable(${originalIdx}, this)" class="collectable-checkbox" aria-label="Mark ${sanitizeHtml(item.name)} as collectable" title="Mark as collectable">
       </td>
       <td><button class="btn" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
-      <td class="delete-cell"><button class="btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item">&times;</button></td>
+      <td><button class="btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">Delete</button></td>
       </tr>
       `);
     }

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -22,12 +22,11 @@ const sortInventory = (data = inventory) => {
       case 5: valA = a.weight; valB = b.weight; break; // Weight
       case 6: valA = a.price; valB = b.price; break; // Purchase Price
       case 7: valA = a.spotPriceAtPurchase; valB = b.spotPriceAtPurchase; break; // Spot Price
-      case 8: valA = a.premiumPerOz; valB = b.premiumPerOz; break; // Premium per oz
-      case 9: valA = a.totalPremium; valB = b.totalPremium; break; // Total Premium
-      case 10: valA = a.purchaseLocation; valB = b.purchaseLocation; break; // Purchase Location
-      case 11: valA = a.storageLocation || 'Unknown'; valB = b.storageLocation || 'Unknown'; break; // Storage Location
-      case 12: valA = a.date; valB = b.date; break; // Date
-      case 13: valA = a.isCollectable; valB = b.isCollectable; break; // Collectable
+      case 8: valA = a.totalPremium; valB = b.totalPremium; break; // Total Premium
+      case 9: valA = a.purchaseLocation; valB = b.purchaseLocation; break; // Purchase Location
+      case 10: valA = a.storageLocation || 'Unknown'; valB = b.storageLocation || 'Unknown'; break; // Storage Location
+      case 11: valA = a.date; valB = b.date; break; // Date
+      case 12: valA = a.isCollectable; valB = b.isCollectable; break; // Collectable
       default: return 0;
     }
 


### PR DESCRIPTION
## Summary
- Clarify table headers for purchase and spot prices as values at purchase time
- Remove per-ounce premium column and add a notes button that shows item notes in a prompt
- Adjust sorting logic to align with new column order and skip sorting on notes/delete columns

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689608441318832eb03370a035741ab5