### PR TITLE
feat: add about modal with disclaimer and version info

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -881,6 +881,38 @@ td input:checked + .slider:before {
   padding-bottom: var(--spacing-sm);
 }
 
+/* ABOUT MODAL STYLES */
+#aboutModal .about-links {
+  margin: var(--spacing-lg) 0;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+#aboutModal .about-links a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+#aboutModal .about-links a:hover {
+  text-decoration: underline;
+}
+
+#aboutModal .version-section {
+  margin-top: var(--spacing-lg);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+#aboutChangelog {
+  margin-top: var(--spacing-sm);
+  background: var(--bg-secondary);
+  padding: var(--spacing);
+  border-radius: var(--radius);
+  max-height: 150px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
 .details-content {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/index.html
+++ b/index.html
@@ -812,6 +812,35 @@ Choose your preferred metals pricing API provider
 </div>
 </div>
 
+<!-- =============================================================================
+       ABOUT/DISCLAIMER MODAL
+
+       Displays project information, version details and last changes.
+       Shown automatically until user accepts the disclaimer.
+       ============================================================================= -->
+<div class="modal" id="aboutModal" style="display: none;">
+  <div class="modal-content">
+    <h2 style="margin-bottom: 1rem; color: var(--primary);">About This App</h2>
+    <p class="about-disclaimer">All data is stored locally in your browser. Back up often and use at your own risk.</p>
+    <p class="about-links">
+      <a href="https://github.com/Precious-Metals-Inventory" target="_blank">GitHub Repository</a>
+      &middot;
+      <a href="README.md" target="_blank">Project README</a>
+    </p>
+    <div class="version-section">
+      <div>Current version: <span id="aboutVersion"></span></div>
+      <div class="changelog">
+        <div>Last version changes:</div>
+        <pre id="aboutChangelog"></pre>
+      </div>
+    </div>
+    <div class="about-buttons" style="margin-top: 1rem; text-align: right;">
+      <button class="btn" id="aboutClose" type="button">Close</button>
+      <button class="btn premium" id="aboutAccept" type="button">Accept</button>
+    </div>
+  </div>
+</div>
+
 <div style="margin-bottom: 1rem;">
 <label for="apiKey">API Key</label>
 <input type="password" id="apiKey" placeholder="Enter your API key" />
@@ -872,6 +901,7 @@ Your API key is stored locally and encrypted
 <script defer src="./js/spot.js"></script>
 <script defer src="./js/api.js"></script>
 <script defer src="./js/inventory.js"></script>
+<script defer src="./js/about.js"></script>
 <script defer src="./js/events.js"></script>
 <script defer src="./js/init.js"></script>
 </body>

--- a/js/about.js
+++ b/js/about.js
@@ -1,0 +1,79 @@
+/**
+ * ABOUT MODAL MODULE
+ *
+ * Handles display and acceptance of the About/Disclaimer modal.
+ * Shows the modal on initial load until the user accepts the disclaimer.
+ */
+
+/**
+ * Displays the about modal
+ */
+function showAboutModal() {
+  const modal = document.getElementById('aboutModal');
+  if (modal) {
+    modal.style.display = 'flex';
+  }
+}
+
+/**
+ * Hides the about modal
+ */
+function hideAboutModal() {
+  const modal = document.getElementById('aboutModal');
+  if (modal) {
+    modal.style.display = 'none';
+  }
+}
+
+/**
+ * Handles acceptance of the disclaimer
+ * Saves a timestamp to localStorage
+ */
+function acceptAboutModal() {
+  try {
+    localStorage.setItem('aboutAccepted', Date.now().toString());
+  } catch (err) {
+    console.warn('Unable to store about acceptance', err);
+  }
+  hideAboutModal();
+}
+
+/**
+ * Loads the latest changelog entry into the modal
+ */
+async function loadLatestChangelog() {
+  try {
+    const res = await fetch('./docs/CHANGELOG.md');
+    const text = await res.text();
+    const match = text.match(/### Version[\s\S]*?(?=\n### Version|$)/);
+    if (match) {
+      const changelogEl = document.getElementById('aboutChangelog');
+      if (changelogEl) {
+        changelogEl.textContent = match[0].trim();
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to load changelog', err);
+  }
+}
+
+// Set up modal on DOM ready
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const versionEl = document.getElementById('aboutVersion');
+    if (versionEl) {
+      versionEl.textContent = typeof APP_VERSION !== 'undefined' ? APP_VERSION : '';
+    }
+    loadLatestChangelog();
+    if (!localStorage.getItem('aboutAccepted')) {
+      showAboutModal();
+    }
+  });
+}
+
+// Expose functions globally
+if (typeof window !== 'undefined') {
+  window.showAboutModal = showAboutModal;
+  window.hideAboutModal = hideAboutModal;
+  window.acceptAboutModal = acceptAboutModal;
+}

--- a/js/events.js
+++ b/js/events.js
@@ -179,6 +179,25 @@ const setupEventListeners = () => {
       console.error('Theme toggle button element not found!');
     }
 
+    // About modal buttons
+    const aboutAccept = document.getElementById('aboutAccept');
+    if (aboutAccept) {
+      safeAttachListener(aboutAccept, 'click', () => {
+        if (typeof acceptAboutModal === 'function') {
+          acceptAboutModal();
+        }
+      }, 'About accept button');
+    }
+
+    const aboutClose = document.getElementById('aboutClose');
+    if (aboutClose) {
+      safeAttachListener(aboutClose, 'click', () => {
+        if (typeof hideAboutModal === 'function') {
+          hideAboutModal();
+        }
+      }, 'About close button');
+    }
+
     // Details modal buttons
     if (elements.detailsButtons && elements.detailsButtons.length) {
       elements.detailsButtons.forEach(btn => {

--- a/js/init.js
+++ b/js/init.js
@@ -46,6 +46,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   console.log(`=== APPLICATION INITIALIZATION STARTED (v${APP_VERSION}) ===`);
 
+  if (!localStorage.getItem('aboutAccepted') && typeof showAboutModal === 'function') {
+    showAboutModal();
+  }
+
   try {
     // Phase 1: Initialize Core DOM Elements
     debugLog('Phase 1: Initializing core DOM elements...');


### PR DESCRIPTION
## Summary
- add about/disclaimer modal with project links, version and changelog
- style about modal and load changelog dynamically
- wire up accept/close buttons and version check on init

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963a4b3904832e884b5e23900cd610