### PR TITLE
Add about modal with disclaimer and version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 The Precious Metals Inventory Tool is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## 🆕 What's New in v3.1.12
-- **About Modal**: Added mandatory disclaimer splash with GitHub link and version info
+- **About Modal**: Mandatory disclaimer splash with version info and refreshed styling
 - **About Button**: Quick access to application details from header
+- **Sources Button**: Fixed link in lower-left to project repository
 
 ## 🆕 What's New in v3.1.11
 - **UI Enhancements**: Improved table usability and visual organization

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Precious Metals Inventory Tool v3.1.11
+# Precious Metals Inventory Tool v3.1.12
 
 The Precious Metals Inventory Tool is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
+
+## 🆕 What's New in v3.1.12
+- **About Modal**: Added mandatory disclaimer splash with GitHub link and version info
+- **About Button**: Quick access to application details from header
 
 ## 🆕 What's New in v3.1.11
 - **UI Enhancements**: Improved table usability and visual organization
@@ -14,6 +18,7 @@ The Precious Metals Inventory Tool is a comprehensive client-side web applicatio
   - Streamlined documentation structure eliminates redundancy
 
 ## Recent Updates in 3.1.x Series
+- **v3.1.11 - UI Enhancements & Documentation**: Improved table usability and consolidated workflow docs
 - **v3.1.10 - Project Maintenance**: Removed orphaned backup and debug files for improved maintainability
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
@@ -183,7 +188,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.1.11
+**Current Version**: 3.1.12
 **Last Updated**: August 8, 2025
 **Status**: Feature complete with enhanced documentation workflow
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -142,16 +142,23 @@ label {
    ============================================================================= */
 
 .app-header {
-  display: flex;
-  align-items: center;
-  margin-bottom: var(--spacing-xl);
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--spacing-xl);
   width: 100%;
   padding: var(--spacing);
   background: var(--bg-card);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-}
+    box-shadow: var(--shadow-sm);
+  }
+
+  .sources-btn {
+    position: fixed;
+    bottom: var(--spacing);
+    left: var(--spacing);
+    z-index: 1000;
+  }
 
 .container {
   display: grid;
@@ -836,17 +843,50 @@ td input:checked + .slider:before {
 }
 
 .modal-content {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-xl);
-  max-width: 600px;
-  width: 100%;
-  max-height: 90vh;
-  overflow-y: auto;
-  box-shadow: var(--shadow-lg);
-  animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-xl);
+    max-width: 600px;
+    width: 100%;
+    max-height: 90vh;
+    overflow-y: auto;
+    box-shadow: var(--shadow-lg);
+    animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  /* About modal styling */
+  #aboutModal .modal-header {
+    background: var(--primary);
+    color: #fff;
+    padding: var(--spacing-lg) var(--spacing-xl);
+    margin: calc(-1 * var(--spacing-xl)) calc(-1 * var(--spacing-xl)) var(--spacing-xl);
+    border-top-left-radius: var(--radius-lg);
+    border-top-right-radius: var(--radius-lg);
+  }
+
+  #aboutModal .modal-body p {
+    margin-bottom: var(--spacing-xl);
+  }
+
+  #aboutModal .section {
+    margin-bottom: var(--spacing-xl);
+  }
+
+  #aboutModal .section-title {
+    font-weight: 600;
+    color: var(--primary);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  #aboutModal ul {
+    margin-left: 1.25rem;
+    list-style: disc;
+  }
+
+  #aboutModal .modal-actions {
+    text-align: right;
+  }
 
 .details-modal-content {
   background: var(--bg-card);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ## 📋 Version History
 
+### Version 3.1.12 – About Modal and Disclaimer (2025-08-08)
+- **User Notice**: Added mandatory about/disclaimer modal informing users that data is stored locally and advising regular backups
+- **About Access**: New About button in header provides version info and change history
+- **Persistence**: Acceptance stored in localStorage to prevent repeated prompts
+
 ### Version 3.1.11 – UI Enhancements and Documentation Consolidation (2025-08-08)
 - **UI Improvements**: Enhanced table usability and visual organization
   - Color-coded table items for improved visual distinction and organization

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,9 @@
 ### Version 3.1.12 – About Modal and Disclaimer (2025-08-08)
 - **User Notice**: Added mandatory about/disclaimer modal informing users that data is stored locally and advising regular backups
 - **About Access**: New About button in header provides version info and change history
+- **Sources Button**: Fixed bottom-left link to project repository
 - **Persistence**: Acceptance stored in localStorage to prevent repeated prompts
+- **Styling**: Refreshed modal header with prominent version display
 
 ### Version 3.1.11 – UI Enhancements and Documentation Consolidation (2025-08-08)
 - **UI Improvements**: Enhanced table usability and visual organization

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - Precious Metals Inventory Tool
 
-## 🎯 Current State: **FEATURE COMPLETE v3.1.11** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **FEATURE COMPLETE v3.1.12** ✅ MAINTAINED & OPTIMIZED
 
-**Precious Metals Inventory Tool v3.1.11** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.1.x series focuses on polish, maintenance, and optimization.
+**Precious Metals Inventory Tool v3.1.12** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.1.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.1.x Series)
 
+- **v3.1.12 - About Modal & Disclaimer**: Added mandatory disclaimer splash and About button with version info
 - **v3.1.11 - UI Enhancements & Documentation**: Improved table usability and AI assistant guidance
   - Color-coded table items for better visual organization
   - Enhanced click-to-sort functionality across all table columns
@@ -102,7 +103,7 @@ All data is stored locally in the browser using localStorage with:
 
 **All documentation files are current and synchronized:**
 - ✅ **STATUS.md** - Updated with 3.1.x series changes and current state
-- ✅ **CHANGELOG.md** - Current through v3.1.11 documentation consolidation
+- ✅ **CHANGELOG.md** - Current through v3.1.12 documentation consolidation
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **STRUCTURE.md** - Reflects streamlined project organization
 - ✅ **VERSIONING.md** - Accurate version management documentation
@@ -111,8 +112,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.1.11 (managed in `js/constants.js`)
-2. **Last Change**: Documentation consolidation - replaced LLM.md with MULTI_AGENT_WORKFLOW.md
+1. **Current Version**: 3.1.12 (managed in `js/constants.js`)
+2. **Last Change**: Added about/disclaimer modal and About button
 3. **Last Documentation Update**: August 8, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase
@@ -128,7 +129,7 @@ If continuing development in a new chat session:
 ```
 PreciousMetalInventoryTool/
 ├── js/                     # Modular JavaScript (cleaned structure)
-│   ├── constants.js        # Version 3.1.11 + metal configs
+│   ├── constants.js        # Version 3.1.12 + metal configs
 │   ├── state.js           # App state + DOM caching
 │   ├── inventory.js       # Core CRUD + notes handling
 │   ├── events.js          # UI event listeners

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.1.x Series)
 
-- **v3.1.12 - About Modal & Disclaimer**: Added mandatory disclaimer splash and About button with version info
+- **v3.1.12 - About Modal & Disclaimer**: Added mandatory disclaimer splash, About header button, and Sources link; modal now includes styled header with version info
 - **v3.1.11 - UI Enhancements & Documentation**: Improved table usability and AI assistant guidance
   - Color-coded table items for better visual organization
   - Enhanced click-to-sort functionality across all table columns

--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
 <h1>Precious Metals Inventory Tool</h1>
 <div style="margin-left: auto; display: flex; gap: 0.5rem;">
 <button class="btn" id="apiBtn" title="API Configuration">API</button>
-<button class="btn" id="themeToggle">Dark Mode</button>
+  <button class="btn" id="aboutBtn" title="About">About</button>
+  <button class="btn" id="themeToggle">Dark Mode</button>
 </div>
 </div>
 <div class="container">
@@ -779,6 +780,31 @@
 </div>
 </div>
 <!-- =============================================================================
+       ABOUT & DISCLAIMER MODAL
+       Provides application information and requires user acceptance.
+       ============================================================================= -->
+<div class="modal" id="aboutModal" style="display: none;">
+  <div class="modal-content">
+    <h2 style="margin-bottom: 1rem; color: var(--primary);">About <span id="aboutVersion"></span></h2>
+    <p style="margin-bottom: 1rem;">All data is stored locally in your browser. Back up often and use at your own risk.</p>
+    <p style="margin-bottom: 1rem;"><a href="https://github.com/jlarmstrongiv/Precious-Metals-Inventory" target="_blank" style="color: var(--primary);">View on GitHub</a></p>
+    <div style="margin-bottom: 1rem;">
+      <div style="font-weight: 600; margin-bottom: 0.5rem;">What's New</div>
+      <ul style="margin-left: 1.25rem; list-style: disc;">
+        <li>Added disclaimer splash requiring acceptance</li>
+        <li>About button for quick access to app details</li>
+      </ul>
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <div style="font-weight: 600; margin-bottom: 0.5rem;">Changes from v3.1.11</div>
+      <ul style="margin-left: 1.25rem; list-style: disc;">
+        <li>UI enhancements and documentation improvements</li>
+      </ul>
+    </div>
+    <div style="text-align: right;"><button class="btn" id="aboutAcceptBtn" style="background: var(--success);">Accept & Continue</button></div>
+  </div>
+</div>
+<!-- =============================================================================
        API CONFIGURATION MODAL
        
        Modal for configuring API providers and keys for live spot price data.
@@ -872,6 +898,7 @@ Your API key is stored locally and encrypted
 <script defer src="./js/spot.js"></script>
 <script defer src="./js/api.js"></script>
 <script defer src="./js/inventory.js"></script>
+<script defer src="./js/about.js"></script>
 <script defer src="./js/events.js"></script>
 <script defer src="./js/init.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -48,9 +48,10 @@
 <button class="btn" id="apiBtn" title="API Configuration">API</button>
   <button class="btn" id="aboutBtn" title="About">About</button>
   <button class="btn" id="themeToggle">Dark Mode</button>
-</div>
-</div>
-<div class="container">
+  </div>
+  </div>
+  <a class="btn sources-btn" href="https://github.com/lbruton/Precious-Metals-Inventory" target="_blank" rel="noopener">Sources</a>
+  <div class="container">
 <!-- =============================================================================
          SPOT PRICES SECTION
          
@@ -785,23 +786,26 @@
        ============================================================================= -->
 <div class="modal" id="aboutModal" style="display: none;">
   <div class="modal-content">
-    <h2 style="margin-bottom: 1rem; color: var(--primary);">About <span id="aboutVersion"></span></h2>
-    <p style="margin-bottom: 1rem;">All data is stored locally in your browser. Back up often and use at your own risk.</p>
-    <p style="margin-bottom: 1rem;"><a href="https://github.com/jlarmstrongiv/Precious-Metals-Inventory" target="_blank" style="color: var(--primary);">View on GitHub</a></p>
-    <div style="margin-bottom: 1rem;">
-      <div style="font-weight: 600; margin-bottom: 0.5rem;">What's New</div>
-      <ul style="margin-left: 1.25rem; list-style: disc;">
-        <li>Added disclaimer splash requiring acceptance</li>
-        <li>About button for quick access to app details</li>
-      </ul>
+    <div class="modal-header">
+      <h2>Precious Metals Inventory Tool <span id="aboutVersion"></span></h2>
     </div>
-    <div style="margin-bottom: 1rem;">
-      <div style="font-weight: 600; margin-bottom: 0.5rem;">Changes from v3.1.11</div>
-      <ul style="margin-left: 1.25rem; list-style: disc;">
-        <li>UI enhancements and documentation improvements</li>
-      </ul>
+    <div class="modal-body">
+      <p>All data is stored locally in your browser. Back up often and use at your own risk.</p>
+      <div class="section">
+        <div class="section-title">What's New</div>
+        <ul>
+          <li>Added disclaimer splash requiring acceptance</li>
+          <li>About button for quick access to app details</li>
+        </ul>
+      </div>
+      <div class="section">
+        <div class="section-title">Changes from v3.1.11</div>
+        <ul>
+          <li>UI enhancements and documentation improvements</li>
+        </ul>
+      </div>
+      <div class="modal-actions"><button class="btn" id="aboutAcceptBtn" style="background: var(--success);">Accept & Continue</button></div>
     </div>
-    <div style="text-align: right;"><button class="btn" id="aboutAcceptBtn" style="background: var(--success);">Accept & Continue</button></div>
   </div>
 </div>
 <!-- =============================================================================

--- a/js/about.js
+++ b/js/about.js
@@ -1,0 +1,55 @@
+// ABOUT & DISCLAIMER MODAL
+// =============================================================================
+
+/**
+ * Shows the about/disclaimer modal
+ */
+const showAboutModal = () => {
+  if (elements.aboutModal) {
+    elements.aboutModal.style.display = 'flex';
+  }
+};
+
+/**
+ * Hides the about/disclaimer modal
+ */
+const hideAboutModal = () => {
+  if (elements.aboutModal) {
+    elements.aboutModal.style.display = 'none';
+  }
+};
+
+/**
+ * Accepts the disclaimer and stores acceptance in localStorage
+ */
+const acceptAbout = () => {
+  try {
+    localStorage.setItem(ABOUT_ACCEPTED_KEY, 'true');
+  } catch (e) {
+    console.warn('Could not access localStorage for disclaimer acceptance', e);
+  }
+  hideAboutModal();
+};
+
+/**
+ * Checks if the disclaimer has been accepted; shows modal if not
+ */
+const checkAboutAcceptance = () => {
+  let accepted = false;
+  try {
+    accepted = localStorage.getItem(ABOUT_ACCEPTED_KEY) === 'true';
+  } catch (e) {
+    console.warn('Could not read disclaimer acceptance from localStorage', e);
+  }
+  if (!accepted) {
+    showAboutModal();
+  }
+};
+
+// Expose globally for access from other modules
+if (typeof window !== 'undefined') {
+  window.showAboutModal = showAboutModal;
+  window.hideAboutModal = hideAboutModal;
+  window.acceptAbout = acceptAbout;
+  window.checkAboutAcceptance = checkAboutAcceptance;
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -63,7 +63,7 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = '3.1.11';
+const APP_VERSION = '3.1.12';
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
 const LS_KEY = 'metalInventory';
@@ -73,6 +73,9 @@ const SPOT_HISTORY_KEY = 'metalSpotHistory';
 
 /** @constant {string} THEME_KEY - LocalStorage key for theme preference */
 const THEME_KEY = 'appTheme';
+
+/** @constant {string} ABOUT_ACCEPTED_KEY - LocalStorage key for disclaimer acceptance */
+const ABOUT_ACCEPTED_KEY = 'aboutAccepted';
 
 /** @constant {string} API_KEY_STORAGE_KEY - LocalStorage key for API provider information */
 const API_KEY_STORAGE_KEY = 'metalApiConfig';

--- a/js/events.js
+++ b/js/events.js
@@ -147,6 +147,16 @@ const setupEventListeners = () => {
       console.error('API button element not found!');
     }
 
+    // About Button
+    if (elements.aboutBtn) {
+      safeAttachListener(elements.aboutBtn, 'click', (e) => {
+        e.preventDefault();
+        if (typeof showAboutModal === 'function') {
+          showAboutModal();
+        }
+      }, 'About Button');
+    }
+
     // Theme Toggle Button
     if (elements.themeToggle) {
       safeAttachListener(elements.themeToggle, 'click', (e) => {
@@ -177,6 +187,16 @@ const setupEventListeners = () => {
       }, 'Theme Toggle');
     } else {
       console.error('Theme toggle button element not found!');
+    }
+
+    // About Modal Accept
+    if (elements.aboutAcceptBtn) {
+      safeAttachListener(elements.aboutAcceptBtn, 'click', (e) => {
+        e.preventDefault();
+        if (typeof acceptAbout === 'function') {
+          acceptAbout();
+        }
+      }, 'About accept');
     }
 
     // Details modal buttons

--- a/js/init.js
+++ b/js/init.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Header buttons - CRITICAL
     debugLog('Phase 2: Initializing header buttons...');
     elements.apiBtn = safeGetElement('apiBtn', true);
+    elements.aboutBtn = safeGetElement('aboutBtn');
     elements.themeToggle = safeGetElement('themeToggle', true);
     
     // Check if critical buttons exist
@@ -92,6 +93,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Modal elements
     debugLog('Phase 4: Initializing modal elements...');
     elements.apiModal = safeGetElement('apiModal');
+    elements.aboutModal = safeGetElement('aboutModal');
+    elements.aboutAcceptBtn = safeGetElement('aboutAcceptBtn');
     elements.editModal = safeGetElement('editModal');
     elements.editForm = safeGetElement('editForm');
     elements.cancelEditBtn = safeGetElement('cancelEdit');
@@ -217,6 +220,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (appHeader) {
       appHeader.textContent = getAppTitle();
     }
+    const aboutVersion = document.getElementById('aboutVersion');
+    if (aboutVersion) {
+      aboutVersion.textContent = `v${APP_VERSION}`;
+    }
 
     // Phase 12: Data Initialization
     debugLog('Phase 12: Loading application data...');
@@ -251,6 +258,9 @@ document.addEventListener('DOMContentLoaded', () => {
         setupSearch();
         setupThemeToggle();
         setupColumnResizing();
+        if (typeof checkAboutAcceptance === 'function') {
+          checkAboutAcceptance();
+        }
         
         debugLog('✓ All event listeners setup complete');
       } catch (eventError) {

--- a/js/state.js
+++ b/js/state.js
@@ -123,6 +123,11 @@ const elements = {
   // Theme toggle
   themeToggle: null,
 
+  // About modal elements
+  aboutBtn: null,
+  aboutModal: null,
+  aboutAcceptBtn: null,
+
   // API elements
   apiBtn: null,
   apiModal: null,


### PR DESCRIPTION
## Summary
- add mandatory about/disclaimer modal with GitHub link and change log
- include About header button and persist acceptance in localStorage
- document new feature and bump version to 3.1.12

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689639554b04832eb0a99acaae81cff0