### PR TITLE
Remove backup button from about modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -871,9 +871,6 @@
           <button class="resource-btn" id="aboutShowChangelogBtn">
             📜 View Full Changelog
           </button>
-          <button class="resource-btn" id="aboutBackupBtn">
-            💾 Backup Data Now
-          </button>
         </div>
       </div>
       

--- a/js/about.js
+++ b/js/about.js
@@ -180,17 +180,6 @@ const extractChangelogItems = (content) => {
 };
 
 /**
- * Handles backup button click from about modal
- */
-const handleAboutBackup = () => {
-  if (typeof window.backupAllData === 'function') {
-    window.backupAllData();
-  } else {
-    console.warn('Backup function not available');
-  }
-};
-
-/**
  * Shows full changelog in a new window or navigates to documentation
  */
 const showFullChangelog = () => {
@@ -211,7 +200,6 @@ const showFullChangelog = () => {
 const setupAboutModalEvents = () => {
   const aboutCloseBtn = document.getElementById('aboutCloseBtn');
   const aboutAcceptBtn = document.getElementById('aboutAcceptBtn');
-  const aboutBackupBtn = document.getElementById('aboutBackupBtn');
   const aboutShowChangelogBtn = document.getElementById('aboutShowChangelogBtn');
   const aboutModal = document.getElementById('aboutModal');
   
@@ -223,11 +211,6 @@ const setupAboutModalEvents = () => {
   // Accept button
   if (aboutAcceptBtn) {
     aboutAcceptBtn.addEventListener('click', acceptAbout);
-  }
-  
-  // Backup button
-  if (aboutBackupBtn) {
-    aboutBackupBtn.addEventListener('click', handleAboutBackup);
   }
   
   // Show changelog button


### PR DESCRIPTION
## Summary
- Remove non-functional backup data button from the About modal
- Drop unused backup handler and event wiring in about.js

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964ef2fc88832ea62762bc7dfbafda