### PR TITLE
Split about popup into acknowledgment and about modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -840,7 +840,7 @@ td input:checked + .slider:before {
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
     padding: var(--spacing-xl);
-    max-width: 600px;
+    max-width: 1200px;
     width: 100%;
     max-height: 90vh;
     overflow-y: auto;
@@ -857,7 +857,7 @@ td input:checked + .slider:before {
 .about-modal-content {
   width: 75vw;
   height: 75vh;
-  max-width: none;
+  max-width: 1200px;
   max-height: none;
   padding: 0;
   overflow: hidden;
@@ -1030,7 +1030,7 @@ td input:checked + .slider:before {
   break-inside: avoid;
 }
 
-.about-alert .alert-actions {
+.alert-actions {
   margin-top: var(--spacing-lg);
   text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -814,15 +814,15 @@
 
           <p><strong>Spot Price Accuracy:</strong> Prices displayed are for reference only and may not reflect real-time market conditions. Always confirm current pricing with your dealer or official market sources before making transactions.</p>
         </div>
-        <div class="alert-actions">
-          <div class="acceptance-text">
-            By continuing, you acknowledge that you understand this tool stores data locally,
-            you are responsible for backing up your data, and you use this application at your own risk.
-          </div>
-          <button class="btn btn-primary about-accept-btn" id="ackAcceptBtn">
-            ✅ I Understand - Continue to Application
-          </button>
+        <div class="acceptance-text">
+          By continuing, you acknowledge that you understand this tool stores data locally,
+          you are responsible for backing up your data, and you use this application at your own risk.
         </div>
+      </div>
+      <div class="alert-actions">
+        <button class="btn btn-primary about-accept-btn" id="ackAcceptBtn">
+          ✅ I Understand - Continue to Application
+        </button>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -784,21 +784,21 @@
        Comprehensive application information and disclaimer modal similar to the
        original splash page design with enhanced features and detailed information.
        ============================================================================= -->
-<div class="modal" id="aboutModal" style="display: none;">
+<div class="modal" id="ackModal" style="display: none;">
   <div class="modal-content about-modal-content">
     <div class="modal-header about-modal-header">
-      <h1 class="about-title" id="aboutTitle">Precious Metals Inventory Tool <span id="aboutVersion"></span></h1>
-      <button aria-label="Close modal" class="modal-close" id="aboutCloseBtn">×</button>
+      <h1 class="about-title">Precious Metals Inventory Tool <span id="ackVersion"></span></h1>
+      <button aria-label="Close modal" class="modal-close" id="ackCloseBtn">×</button>
     </div>
     <div class="modal-body about-modal-body">
       <!-- Application Description -->
       <div class="about-description">
-        Track your precious metal investments with comprehensive spot price tracking, premium calculations, 
-        and detailed reporting. Add items to your inventory, monitor current values across Silver, Gold, 
-        Platinum, and Palladium, and export your data in multiple formats including CSV, JSON, Excel, 
+        Track your precious metal investments with comprehensive spot price tracking, premium calculations,
+        and detailed reporting. Add items to your inventory, monitor current values across Silver, Gold,
+        Platinum, and Palladium, and export your data in multiple formats including CSV, JSON, Excel,
         PDF, and HTML.
       </div>
-      
+
       <!-- Important Notice -->
       <div class="about-alert">
         <div class="alert-header">
@@ -807,11 +807,11 @@
         </div>
         <div class="alert-content">
           <p><strong>Your Privacy is Protected:</strong> All data is stored locally in your browser using localStorage and <em>never transmitted to any server</em>. Your precious metals inventory information remains completely private and under your control.</p>
-          
+
           <p><strong>Data Backup Responsibility:</strong> Since data is stored locally, it will be lost if you clear browser history, reset browser data, or use private browsing mode. Use the "Backup All Data" feature regularly to save your information.</p>
-          
+
           <p><strong>Use at Your Own Risk:</strong> This tool is provided for informational and organizational purposes only. The developer assumes no responsibility for any financial decisions, investment choices, or data loss. Always verify spot prices and calculations independently.</p>
-          
+
           <p><strong>Spot Price Accuracy:</strong> Prices displayed are for reference only and may not reflect real-time market conditions. Always confirm current pricing with your dealer or official market sources before making transactions.</p>
         </div>
         <div class="alert-actions">
@@ -819,12 +819,21 @@
             By continuing, you acknowledge that you understand this tool stores data locally,
             you are responsible for backing up your data, and you use this application at your own risk.
           </div>
-          <button class="btn btn-primary about-accept-btn" id="aboutAcceptBtn">
+          <button class="btn btn-primary about-accept-btn" id="ackAcceptBtn">
             ✅ I Understand - Continue to Application
           </button>
         </div>
       </div>
-
+    </div>
+  </div>
+</div>
+<div class="modal" id="aboutModal" style="display: none;">
+  <div class="modal-content about-modal-content">
+    <div class="modal-header about-modal-header">
+      <h1 class="about-title" id="aboutTitle">Precious Metals Inventory Tool <span id="aboutVersion"></span></h1>
+      <button aria-label="Close modal" class="modal-close" id="aboutCloseBtn">×</button>
+    </div>
+    <div class="modal-body about-modal-body">
       <!-- Key Features -->
       <div class="about-features">
         <div class="features-title">✨ Key Features</div>

--- a/js/about.js
+++ b/js/about.js
@@ -2,7 +2,7 @@
 // =============================================================================
 
 /**
- * Shows the about/disclaimer modal and populates it with current data
+ * Shows the About modal and populates it with current data
  */
 const showAboutModal = () => {
   if (elements.aboutModal) {
@@ -13,7 +13,7 @@ const showAboutModal = () => {
 };
 
 /**
- * Hides the about/disclaimer modal
+ * Hides the About modal
  */
 const hideAboutModal = () => {
   if (elements.aboutModal) {
@@ -23,10 +23,33 @@ const hideAboutModal = () => {
 };
 
 /**
- * Accepts the disclaimer and simply hides the modal
+ * Shows the acknowledgment modal on load
  */
-const acceptAbout = () => {
-  hideAboutModal();
+const showAckModal = () => {
+  const ackModal = document.getElementById('ackModal');
+  if (ackModal) {
+    populateAckModal();
+    ackModal.style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+/**
+ * Hides the acknowledgment modal
+ */
+const hideAckModal = () => {
+  const ackModal = document.getElementById('ackModal');
+  if (ackModal) {
+    ackModal.style.display = 'none';
+    document.body.style.overflow = '';
+  }
+};
+
+/**
+ * Accepts the acknowledgment and hides the modal
+ */
+const acceptAck = () => {
+  hideAckModal();
 };
 
 /**
@@ -36,17 +59,27 @@ const populateAboutModal = () => {
   // Update version displays
   const aboutVersion = document.getElementById('aboutVersion');
   const aboutCurrentVersion = document.getElementById('aboutCurrentVersion');
-  
+
   if (aboutVersion && typeof APP_VERSION !== 'undefined') {
     aboutVersion.textContent = `v${APP_VERSION}`;
   }
-  
+
   if (aboutCurrentVersion && typeof APP_VERSION !== 'undefined') {
     aboutCurrentVersion.textContent = `v${APP_VERSION}`;
   }
-  
+
   // Load changelog data
   loadChangelog();
+};
+
+/**
+ * Populates the acknowledgment modal with version information
+ */
+const populateAckModal = () => {
+  const ackVersion = document.getElementById('ackVersion');
+  if (ackVersion && typeof APP_VERSION !== 'undefined') {
+    ackVersion.textContent = `v${APP_VERSION}`;
+  }
 };
 
 /**
@@ -179,25 +212,19 @@ const showFullChangelog = () => {
  */
 const setupAboutModalEvents = () => {
   const aboutCloseBtn = document.getElementById('aboutCloseBtn');
-  const aboutAcceptBtn = document.getElementById('aboutAcceptBtn');
   const aboutShowChangelogBtn = document.getElementById('aboutShowChangelogBtn');
   const aboutModal = document.getElementById('aboutModal');
-  
+
   // Close button
   if (aboutCloseBtn) {
     aboutCloseBtn.addEventListener('click', hideAboutModal);
   }
-  
-  // Accept button
-  if (aboutAcceptBtn) {
-    aboutAcceptBtn.addEventListener('click', acceptAbout);
-  }
-  
+
   // Show changelog button
   if (aboutShowChangelogBtn) {
     aboutShowChangelogBtn.addEventListener('click', showFullChangelog);
   }
-  
+
   // Click outside to close
   if (aboutModal) {
     aboutModal.addEventListener('click', (e) => {
@@ -206,7 +233,7 @@ const setupAboutModalEvents = () => {
       }
     });
   }
-  
+
   // Escape key to close
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && aboutModal && aboutModal.style.display === 'flex') {
@@ -215,12 +242,47 @@ const setupAboutModalEvents = () => {
   });
 };
 
+/**
+ * Sets up event listeners for acknowledgment modal elements
+ */
+const setupAckModalEvents = () => {
+  const ackCloseBtn = document.getElementById('ackCloseBtn');
+  const ackAcceptBtn = document.getElementById('ackAcceptBtn');
+  const ackModal = document.getElementById('ackModal');
+
+  if (ackCloseBtn) {
+    ackCloseBtn.addEventListener('click', hideAckModal);
+  }
+
+  if (ackAcceptBtn) {
+    ackAcceptBtn.addEventListener('click', acceptAck);
+  }
+
+  if (ackModal) {
+    ackModal.addEventListener('click', (e) => {
+      if (e.target === ackModal) {
+        hideAckModal();
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && ackModal && ackModal.style.display === 'flex') {
+      hideAckModal();
+    }
+  });
+};
+
 // Expose globally for access from other modules
 if (typeof window !== 'undefined') {
   window.showAboutModal = showAboutModal;
   window.hideAboutModal = hideAboutModal;
-  window.acceptAbout = acceptAbout;
+  window.showAckModal = showAckModal;
+  window.hideAckModal = hideAckModal;
+  window.acceptAck = acceptAck;
   window.loadChangelog = loadChangelog;
   window.setupAboutModalEvents = setupAboutModalEvents;
+  window.setupAckModalEvents = setupAckModalEvents;
   window.populateAboutModal = populateAboutModal;
+  window.populateAckModal = populateAckModal;
 }

--- a/js/init.js
+++ b/js/init.js
@@ -94,7 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
     debugLog('Phase 4: Initializing modal elements...');
     elements.apiModal = safeGetElement('apiModal');
     elements.aboutModal = safeGetElement('aboutModal');
-    elements.aboutAcceptBtn = safeGetElement('aboutAcceptBtn');
+    elements.ackModal = safeGetElement('ackModal');
+    elements.ackAcceptBtn = safeGetElement('ackAcceptBtn');
     elements.editModal = safeGetElement('editModal');
     elements.editForm = safeGetElement('editForm');
     elements.cancelEditBtn = safeGetElement('cancelEdit');
@@ -110,12 +111,15 @@ document.addEventListener('DOMContentLoaded', () => {
     elements.editDate = safeGetElement('editDate');
     elements.editSpotPrice = safeGetElement('editSpotPrice');
 
-    // Show About modal immediately and set up its events
+    // Show acknowledgment modal immediately and set up modal events
+    if (typeof setupAckModalEvents === 'function') {
+      setupAckModalEvents();
+    }
+    if (typeof showAckModal === 'function') {
+      showAckModal();
+    }
     if (typeof setupAboutModalEvents === 'function') {
       setupAboutModalEvents();
-    }
-    if (typeof showAboutModal === 'function') {
-      showAboutModal();
     }
 
     // Notes modal elements

--- a/js/state.js
+++ b/js/state.js
@@ -123,10 +123,11 @@ const elements = {
   // Theme toggle
   themeToggle: null,
 
-  // About modal elements
+  // About & acknowledgment modal elements
   aboutBtn: null,
   aboutModal: null,
-  aboutAcceptBtn: null,
+  ackModal: null,
+  ackAcceptBtn: null,
 
   // API elements
   apiBtn: null,


### PR DESCRIPTION
## Summary
- Separate initial disclaimer into new acknowledgment modal displayed on load
- Keep feature and changelog details in updated About modal triggered by About button
- Add JS logic and initialization for new modal pair with shared version handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965babdb08832e8489a396f7751976