### PR TITLE
feat: frame settings and add custom api option

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -31,7 +31,8 @@
   --border-hover: #cbd5e1;
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 
   /* Metal-specific Colors - tuned for light mode */
   --silver: #6b7280;
@@ -81,21 +82,30 @@
   --border-hover: #475569;
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
   --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
-  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3), 0 4px 6px -4px rgb(0 0 0 / 0.3);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.3), 0 4px 6px -4px rgb(0 0 0 / 0.3);
 }
 
 /* =============================================================================
    BASE STYLES & RESET
    ============================================================================= */
 
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 html {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
   background: var(--bg-primary);
   color: var(--text-primary);
   -webkit-font-smoothing: antialiased;
@@ -142,16 +152,28 @@ label {
    ============================================================================= */
 
 .app-header {
-    display: flex;
-    align-items: center;
-    margin-bottom: var(--spacing-xl);
+  display: flex;
+  align-items: center;
+  margin-bottom: var(--spacing-xl);
   width: 100%;
   padding: var(--spacing);
   background: var(--bg-card);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
-    box-shadow: var(--shadow-sm);
-  }
+  box-shadow: var(--shadow-sm);
+}
+
+.header-buttons {
+  margin-left: auto;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.icon-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1;
+}
 
 .container {
   display: grid;
@@ -189,13 +211,16 @@ form {
   gap: var(--spacing);
 }
 
-input, select, button {
+input,
+select,
+button {
   font-family: inherit;
   font-size: 1rem;
   transition: var(--transition);
 }
 
-input, select {
+input,
+select {
   width: 100%;
   padding: 0.75rem;
   border: 2px solid var(--border);
@@ -204,7 +229,8 @@ input, select {
   color: var(--text-primary);
 }
 
-input:focus, select:focus {
+input:focus,
+select:focus {
   outline: none;
   border-color: var(--primary);
   box-shadow: 0 0 0 3px rgb(59 130 246 / 0.1);
@@ -252,7 +278,10 @@ input:focus, select:focus {
 }
 
 /* Force cursor pointer for all buttons */
-button, .btn, input[type="button"], input[type="submit"] {
+button,
+.btn,
+input[type="button"],
+input[type="submit"] {
   cursor: pointer !important;
 }
 
@@ -289,13 +318,18 @@ button, .btn, input[type="button"], input[type="submit"] {
 }
 
 .btn::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
   transition: left 0.5s;
 }
 
@@ -423,34 +457,233 @@ button, .btn, input[type="button"], input[type="submit"] {
   margin-bottom: var(--spacing-sm);
 }
 
-/* API Button Styling */
-#apiBtn {
-  background: var(--warning);
-  color: var(--text-primary);
+/* Settings Modal - API Provider Blocks */
+.settings-section {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.api-providers {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.api-provider {
+  padding: 0.75rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.api-provider input[type="password"] {
+  width: 100%;
+}
+
+.api-key-note {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: 0.25rem;
+}
+
+.provider-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 0.25rem;
   font-weight: 600;
+  gap: 0.25rem;
 }
 
-#apiBtn:hover {
-  background: #b45309;
+.provider-url {
+  font-weight: normal;
+  font-size: 0.875rem;
+  color: var(--text-muted);
 }
 
-/* API Status Indicators */
-.api-status-connected {
-  background: linear-gradient(135deg, #d1fae5, #a7f3d0) !important;
-  border-color: var(--success) !important;
+.api-info-link {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--primary);
+  text-decoration: underline;
+  cursor: pointer;
 }
 
-.api-status-error {
-  background: linear-gradient(135deg, #fee2e2, #fecaca) !important;
-  border-color: var(--danger) !important;
+.provider-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
 }
 
-[data-theme="dark"] .api-status-connected {
-  background: linear-gradient(135deg, #064e3b, #065f46) !important;
+.provider-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
-[data-theme="dark"] .api-status-error {
-  background: linear-gradient(135deg, #7f1d1d, #991b1b) !important;
+.provider-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+}
+
+.cache-duration-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.api-key-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.provider-status {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.provider-status .status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--warning);
+}
+
+.provider-status .status-text {
+  color: var(--warning);
+}
+
+.provider-status.status-connected .status-dot {
+  background: var(--success);
+}
+
+.provider-status.status-connected .status-text {
+  color: var(--success);
+}
+
+.provider-status.status-error .status-dot {
+  background: var(--danger);
+}
+
+.provider-status.status-error .status-text {
+  color: var(--danger);
+}
+
+.settings-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.theme-options {
+  display: flex;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+/* Info modal sizing */
+#apiInfoModal .modal-content {
+  max-width: 500px;
+}
+
+#apiInfoModal h3 {
+  margin-bottom: 1rem;
+}
+
+#apiInfoModal .modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+.api-info-body {
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+  background: var(--bg-tertiary);
+  padding: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.api-info-body .info-provider-name {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.api-info-body ul {
+  margin: 0.5rem 0 0 1.25rem;
+}
+
+.api-info-body li + li {
+  margin-top: 0.25rem;
+}
+
+.api-info-body .info-docs-btn {
+  margin-top: 0.75rem;
+}
+
+/* Settings modal layout */
+#settingsModal .modal-content {
+  max-width: 600px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+#settingsModal .modal-header {
+  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+  color: white;
+  padding: var(--spacing-xl);
+  position: relative;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: var(--shadow);
+}
+
+#settingsModal .modal-header h2 {
+  margin: 0;
+  color: white;
+  text-align: center;
+}
+
+#settingsModal .modal-body {
+  padding: var(--spacing-xl);
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--bg-secondary);
+}
+
+#settingsModal .modal-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+#settingsModal .modal-body::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+  border-radius: var(--radius);
+}
+
+#settingsModal .modal-body::-webkit-scrollbar-thumb {
+  background-color: var(--primary);
+  border-radius: var(--radius);
+}
+
+#settingsModal .modal-body::-webkit-scrollbar-thumb:hover {
+  background-color: var(--primary-hover);
 }
 
 /* =============================================================================
@@ -548,21 +781,24 @@ button, .btn, input[type="button"], input[type="submit"] {
 }
 
 .details-btn::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
   transition: left 0.5s;
 }
 
 .details-btn:hover::before {
   left: 100%;
 }
-
-
 
 .total-title {
   font-size: 1.125rem;
@@ -572,19 +808,33 @@ button, .btn, input[type="button"], input[type="submit"] {
   text-align: center;
   padding-bottom: var(--spacing-sm);
   border-bottom: 4px solid var(--border); /* fallback, will be overridden below */
-  transition: border-color 0.2s, color 0.2s;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
 }
 
 /* Metal-specific underline accent */
-.silver .total-title { border-bottom: 4px solid var(--silver); }
-.gold .total-title { border-bottom: 4px solid var(--gold); }
-.platinum .total-title { border-bottom: 4px solid var(--platinum); }
-.palladium .total-title { border-bottom: 4px solid var(--palladium); }
+.silver .total-title {
+  border-bottom: 4px solid var(--silver);
+}
+.gold .total-title {
+  border-bottom: 4px solid var(--gold);
+}
+.platinum .total-title {
+  border-bottom: 4px solid var(--platinum);
+}
+.palladium .total-title {
+  border-bottom: 4px solid var(--palladium);
+}
 /* Metal-specific colors */
-.silver .total-title {  }
-.gold .total-title {  }
-.platinum .total-title {  }
-.palladium .total-title {  }
+.silver .total-title {
+}
+.gold .total-title {
+}
+.platinum .total-title {
+}
+.palladium .total-title {
+}
 
 /* =============================================================================
    TABLES - Main inventory table with interactive features
@@ -607,7 +857,7 @@ table {
   border-radius: var(--radius);
   overflow: hidden;
   box-shadow: var(--shadow);
-table-layout: auto; /* Allow columns to size based on content */
+  table-layout: auto; /* Allow columns to size based on content */
 }
 
 th {
@@ -701,7 +951,7 @@ tr:hover {
 }
 
 .clickable-name::after {
-  content: '✎';
+  content: "✎";
   position: absolute;
   right: 2px;
   top: 50%;
@@ -731,7 +981,9 @@ tr:hover {
   transform: scale(1.2);
   accent-color: var(--primary);
   border-radius: 3px;
-  transition: transform 0.2s, box-shadow 0.2s;
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
 }
 
 .collectable-checkbox:hover {
@@ -836,19 +1088,17 @@ td input:checked + .slider:before {
 }
 
 .modal-content {
-    background: var(--bg-card);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    padding: var(--spacing-xl);
-    max-width: 1200px;
-    width: 100%;
-    max-height: 90vh;
-    overflow-y: auto;
-    box-shadow: var(--shadow-lg);
-    animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-
-  
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-xl);
+  max-width: 1200px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-lg);
+  animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
 
 /* =============================================================================
    ABOUT MODAL STYLING - Enhanced splash page design
@@ -879,7 +1129,11 @@ td input:checked + .slider:before {
   margin: 0;
   color: white;
   text-align: center;
-  background: linear-gradient(135deg, rgba(255,255,255,1), rgba(255,255,255,0.8));
+  background: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 1),
+    rgba(255, 255, 255, 0.8)
+  );
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -892,7 +1146,7 @@ td input:checked + .slider:before {
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: rgba(255,255,255,0.8);
+  color: rgba(255, 255, 255, 0.8);
   cursor: pointer;
   padding: var(--spacing-sm);
   border-radius: var(--radius);
@@ -906,7 +1160,7 @@ td input:checked + .slider:before {
 
 .modal-close:hover {
   color: white;
-  background: rgba(255,255,255,0.1);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .about-modal-body {
@@ -1088,7 +1342,7 @@ td input:checked + .slider:before {
 }
 
 .changelog-list li::before {
-  content: '•';
+  content: "•";
   color: var(--primary);
   font-weight: bold;
   font-size: 1.2em;
@@ -1122,7 +1376,7 @@ td input:checked + .slider:before {
 }
 
 .roadmap-list li::before {
-  content: '→';
+  content: "→";
   color: var(--primary);
   font-weight: bold;
   margin-right: var(--spacing-sm);
@@ -1223,12 +1477,12 @@ td input:checked + .slider:before {
   .about-title {
     font-size: 1.25rem;
   }
-  
+
   .about-description {
     font-size: 1rem;
     padding: var(--spacing);
   }
-  
+
   .about-modal-header {
     padding: var(--spacing);
   }
@@ -1565,6 +1819,20 @@ td input:checked + .slider:before {
   cursor: pointer;
 }
 
+.import-progress {
+  width: 100%;
+  margin-top: var(--spacing-sm);
+  display: none;
+}
+
+.import-progress-text {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  margin-top: var(--spacing-sm);
+  display: none;
+}
+
 /* =============================================================================
    TOGGLE SWITCHES
    ============================================================================= */
@@ -1831,7 +2099,7 @@ input:disabled + .slider {
     font-size: 0.7rem;
     padding: 0.25rem 0.125rem;
   }
-  
+
   td {
     font-size: 0.7rem;
     padding: 0.2rem;
@@ -1843,12 +2111,12 @@ input:disabled + .slider {
     font-size: 0.65rem;
     padding: 0.2rem 0.1rem;
   }
-  
+
   td {
     font-size: 0.65rem;
     padding: 0.15rem;
   }
-  
+
   td .btn {
     padding: 0.2rem 0.3rem;
     font-size: 0.65rem;

--- a/index.html
+++ b/index.html
@@ -67,10 +67,23 @@
     <!-- Application Header -->
     <div class="app-header">
       <h1>Precious Metals Inventory Tool</h1>
-      <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button class="btn" id="apiBtn" title="API Configuration">API</button>
-        <button class="btn" id="aboutBtn" title="About">About</button>
-        <button class="btn" id="themeToggle">Dark Mode</button>
+      <div class="header-buttons">
+        <button
+          class="btn icon-btn"
+          id="aboutBtn"
+          title="About"
+          aria-label="About"
+        >
+          📖
+        </button>
+        <button
+          class="btn icon-btn"
+          id="settingsBtn"
+          title="Settings"
+          aria-label="Settings"
+        >
+          ⚙️
+        </button>
       </div>
     </div>
     <div class="container">
@@ -816,6 +829,13 @@
             />
           </label>
         </div>
+        <progress
+          class="import-progress"
+          id="importProgress"
+          value="0"
+          max="0"
+        ></progress>
+        <div class="import-progress-text" id="importProgressText"></div>
         <h2>Export Options</h2>
         <div class="export-section import-export-grid">
           <button class="btn" id="exportCsvBtn">Export CSV</button>
@@ -1193,12 +1213,6 @@
               </button>
             </div>
           </div>
-
-          <div class="about-section boating-accident-section">
-            <button id="boatingAccidentBtn">
-              So you had a boating accident?
-            </button>
-          </div>
         </div>
       </div>
     </div>
@@ -1209,167 +1223,323 @@
        Includes provider selection, API key input, and status display.
        Data is stored in localStorage with 24-hour caching system.
        ============================================================================= -->
-    <div class="modal" id="apiModal" style="display: none">
+    <div class="modal" id="settingsModal" style="display: none">
       <div class="modal-content">
-        <h2 style="margin-bottom: 1rem; color: var(--primary)">
-          API Configuration
-        </h2>
-        <p
-          style="
-            color: var(--text-secondary);
-            margin-bottom: 1.5rem;
-            font-size: 0.875rem;
-          "
-        >
-          Configure an API provider to automatically sync spot prices. Your API
-          key is stored locally and never transmitted to our servers.
-        </p>
-
-        <!-- API Status Display -->
-        <div
-          id="apiStatusDisplay"
-          style="
-            margin-bottom: 1rem;
-            padding: 0.75rem;
-            border-radius: var(--radius);
-            background: var(--bg-secondary);
-            border: 1px solid var(--border);
-          "
-        >
-          <div id="apiStatusText">No API configured</div>
-          <div
-            id="apiCacheInfo"
-            style="
-              font-size: 0.75rem;
-              color: var(--text-muted);
-              margin-top: 0.25rem;
-            "
-          ></div>
+        <div class="modal-header">
+          <h2>Settings</h2>
+          <button
+            aria-label="Close modal"
+            class="modal-close"
+            id="settingsCloseBtn"
+          >
+            ×
+          </button>
         </div>
-
-        <form id="apiConfigForm">
-          <div style="margin-bottom: 1rem">
-            <label for="apiProvider">API Provider</label>
-            <select id="apiProvider">
-              <option value="">Select a provider...</option>
-              <option value="METALS_DEV">Metals.dev</option>
-              <option value="METALS_API">Metals-API.com</option>
-              <option value="METAL_PRICE_API">MetalPriceAPI.com</option>
-            </select>
-            <div
-              style="
-                font-size: 0.75rem;
-                color: var(--text-muted);
-                margin-top: 0.25rem;
-              "
-            >
-              Choose your preferred metals pricing API provider
+        <div class="modal-body">
+          <div class="settings-section">
+            <h3>Appearance</h3>
+            <div class="theme-options">
+              <label
+                ><input type="radio" name="themePreference" value="light" />
+                Light Default</label
+              >
+              <label
+                ><input type="radio" name="themePreference" value="dark" /> Dark
+                Default</label
+              >
+              <label
+                ><input type="radio" name="themePreference" value="system" />
+                Follow System</label
+              >
             </div>
           </div>
 
-          <div style="margin-bottom: 1rem">
-            <label for="apiKey">API Key</label>
-            <input
-              type="password"
-              id="apiKey"
-              placeholder="Enter your API key"
-            />
-            <div
-              style="
-                font-size: 0.75rem;
-                color: var(--text-muted);
-                margin-top: 0.25rem;
-              "
-            >
-              Your API key is stored locally and encrypted
+          <div class="settings-section">
+            <h3>API Configuration</h3>
+
+            <div class="api-providers">
+              <div class="api-provider" data-provider="METALS_DEV">
+                <div class="provider-header">
+                  <span class="provider-name">Metals.dev</span>
+                  <span class="provider-url">https://api.metals.dev/v1</span>
+                </div>
+                <a href="#" class="api-info-link" data-provider="METALS_DEV"
+                  >Provider Information</a
+                >
+                <div class="api-key-row">
+                  <label for="apiKey_METALS_DEV">Key:</label>
+                  <input
+                    type="password"
+                    id="apiKey_METALS_DEV"
+                    placeholder="Enter your API key"
+                  />
+                </div>
+                <div class="provider-footer">
+                  <div class="provider-info">
+                    <div class="api-key-note">
+                      Your API key is stored locally and never shared.
+                    </div>
+                    <div class="provider-status">
+                      <span class="status-dot"></span>
+                      <span class="status-text">Disconnected</span>
+                    </div>
+                  </div>
+                  <div class="provider-actions">
+                    <button
+                      type="button"
+                      class="btn api-sync-btn"
+                      data-provider="METALS_DEV"
+                    >
+                      Test & Sync
+                    </button>
+                    <button
+                      type="button"
+                      class="btn api-clear-btn"
+                      data-provider="METALS_DEV"
+                    >
+                      Clear Key
+                    </button>
+                    <label
+                      ><input
+                        type="radio"
+                        name="defaultProvider"
+                        value="METALS_DEV"
+                        checked
+                      />
+                      Default</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="api-provider" data-provider="METALS_API">
+                <div class="provider-header">
+                  <span class="provider-name">Metals-API.com</span>
+                  <span class="provider-url">https://metals-api.com/api</span>
+                </div>
+                <a href="#" class="api-info-link" data-provider="METALS_API"
+                  >Provider Information</a
+                >
+                <div class="api-key-row">
+                  <label for="apiKey_METALS_API">Key:</label>
+                  <input
+                    type="password"
+                    id="apiKey_METALS_API"
+                    placeholder="Enter your API key"
+                  />
+                </div>
+                <div class="provider-footer">
+                  <div class="provider-info">
+                    <div class="api-key-note">
+                      Your API key is stored locally and never shared.
+                    </div>
+                    <div class="provider-status">
+                      <span class="status-dot"></span>
+                      <span class="status-text">Disconnected</span>
+                    </div>
+                  </div>
+                  <div class="provider-actions">
+                    <button
+                      type="button"
+                      class="btn api-sync-btn"
+                      data-provider="METALS_API"
+                    >
+                      Test & Sync
+                    </button>
+                    <button
+                      type="button"
+                      class="btn api-clear-btn"
+                      data-provider="METALS_API"
+                    >
+                      Clear Key
+                    </button>
+                    <label
+                      ><input
+                        type="radio"
+                        name="defaultProvider"
+                        value="METALS_API"
+                      />
+                      Default</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="api-provider" data-provider="METAL_PRICE_API">
+                <div class="provider-header">
+                  <span class="provider-name">MetalPriceAPI.com</span>
+                  <span class="provider-url">
+                    https://api.metalpriceapi.com/v1
+                  </span>
+                </div>
+                <a
+                  href="#"
+                  class="api-info-link"
+                  data-provider="METAL_PRICE_API"
+                  >Provider Information</a
+                >
+                <div class="api-key-row">
+                  <label for="apiKey_METAL_PRICE_API">Key:</label>
+                  <input
+                    type="password"
+                    id="apiKey_METAL_PRICE_API"
+                    placeholder="Enter your API key"
+                  />
+                </div>
+                <div class="provider-footer">
+                  <div class="provider-info">
+                    <div class="api-key-note">
+                      Your API key is stored locally and never shared.
+                    </div>
+                    <div class="provider-status">
+                      <span class="status-dot"></span>
+                      <span class="status-text">Disconnected</span>
+                    </div>
+                  </div>
+                  <div class="provider-actions">
+                    <button
+                      type="button"
+                      class="btn api-sync-btn"
+                      data-provider="METAL_PRICE_API"
+                    >
+                      Test & Sync
+                    </button>
+                    <button
+                      type="button"
+                      class="btn api-clear-btn"
+                      data-provider="METAL_PRICE_API"
+                    >
+                      Clear Key
+                    </button>
+                    <label
+                      ><input
+                        type="radio"
+                        name="defaultProvider"
+                        value="METAL_PRICE_API"
+                      />
+                      Default</label
+                    >
+                  </div>
+                </div>
+              </div>
+
+              <div class="api-provider" data-provider="CUSTOM">
+                <div class="provider-header">
+                  <span class="provider-name">Custom</span>
+                  <span class="provider-url" id="customBaseUrlDisplay"
+                    >User-defined</span
+                  >
+                </div>
+                <a href="#" class="api-info-link" data-provider="CUSTOM"
+                  >Provider Information</a
+                >
+                <div class="api-key-row">
+                  <label for="customBaseUrl">Base URL:</label>
+                  <input
+                    type="text"
+                    id="customBaseUrl"
+                    placeholder="https://example.com/api"
+                  />
+                </div>
+                <div class="api-key-row">
+                  <label for="customEndpoint">Endpoint:</label>
+                  <input
+                    type="text"
+                    id="customEndpoint"
+                    placeholder="/spot?key={API_KEY}&metal={METAL}"
+                  />
+                </div>
+                <div class="api-key-row">
+                  <label for="apiKey_CUSTOM">Key:</label>
+                  <input
+                    type="password"
+                    id="apiKey_CUSTOM"
+                    placeholder="Enter your API key"
+                  />
+                </div>
+                <div class="api-key-row">
+                  <label for="customMetalFormat">Metal Format:</label>
+                  <select id="customMetalFormat">
+                    <option value="word">Word</option>
+                    <option value="symbol">Symbol</option>
+                  </select>
+                </div>
+                <div class="provider-footer">
+                  <div class="provider-info">
+                    <div class="api-key-note">
+                      Your API key is stored locally and never shared.
+                    </div>
+                    <div class="provider-status">
+                      <span class="status-dot"></span>
+                      <span class="status-text">Disconnected</span>
+                    </div>
+                  </div>
+                  <div class="provider-actions">
+                    <button
+                      type="button"
+                      class="btn api-sync-btn"
+                      data-provider="CUSTOM"
+                    >
+                      Test & Sync
+                    </button>
+                    <button
+                      type="button"
+                      class="btn api-clear-btn"
+                      data-provider="CUSTOM"
+                    >
+                      Clear Key
+                    </button>
+                    <label
+                      ><input
+                        type="radio"
+                        name="defaultProvider"
+                        value="CUSTOM"
+                      />
+                      Default</label
+                    >
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="cache-duration-row">
+              <label for="apiCacheDuration">Cache Duration:</label>
+              <select id="apiCacheDuration">
+                <option value="0">No Cache</option>
+                <option value="1">1 hour</option>
+                <option value="6">6 hours</option>
+                <option value="12">12 hours</option>
+                <option value="24">24 hours</option>
+              </select>
+            </div>
+
+            <div class="settings-actions">
+              <button type="button" class="btn" id="clearApiCacheBtn">
+                Clear API Cache
+              </button>
             </div>
           </div>
 
-          <div style="margin-bottom: 1rem">
-            <label>
-              <input type="checkbox" id="testConnection" checked /> Test
-              connection when saving
-            </label>
+          <div class="settings-section">
+            <h3>Files</h3>
+            <p>File settings coming soon.</p>
           </div>
+          <div class="settings-section boating-accident-section">
+            <button id="boatingAccidentBtn">
+              🏴‍☠️ So you had a boating accident?
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
-          <!-- Provider Information Panel -->
-          <div
-            id="providerInfo"
-            style="
-              display: none;
-              margin-bottom: 1rem;
-              padding: 0.75rem;
-              background: var(--bg-tertiary);
-              border-radius: var(--radius);
-              border: 1px solid var(--border);
-            "
-          >
-            <div style="font-weight: 600; margin-bottom: 0.5rem">
-              Provider Information
-            </div>
-            <div
-              id="providerDetails"
-              style="font-size: 0.875rem; color: var(--text-secondary)"
-            ></div>
-            <a
-              id="providerDocs"
-              href="#"
-              target="_blank"
-              style="
-                color: var(--primary);
-                font-size: 0.875rem;
-                text-decoration: none;
-              "
-              >📄 View Documentation</a
-            >
-          </div>
-
-          <!-- Action buttons -->
-          <div
-            style="
-              display: flex;
-              gap: 0.75rem;
-              justify-content: flex-end;
-              margin-top: 1.5rem;
-            "
-          >
-            <button type="button" class="btn" id="apiCancelBtn">Cancel</button>
-            <button
-              type="button"
-              class="btn"
-              id="apiSyncNowBtn"
-              style="background: var(--primary)"
-              title="Force sync fresh data from API now"
-            >
-              Sync Now
-            </button>
-            <button
-              type="button"
-              class="btn"
-              id="apiClearCacheBtn"
-              style="background: var(--info)"
-              title="Clear cached data to force fresh API sync on next sync"
-            >
-              Clear Cache
-            </button>
-            <button
-              type="button"
-              class="btn"
-              id="apiClearBtn"
-              style="background: var(--warning)"
-            >
-              Clear Config
-            </button>
-            <button
-              type="submit"
-              class="btn"
-              id="apiSaveBtn"
-              style="background: var(--success)"
-            >
-              Save & Test
-            </button>
-          </div>
-        </form>
+    <div class="modal" id="apiInfoModal" style="display: none">
+      <div class="modal-content">
+        <h3 id="apiInfoTitle">Provider Information</h3>
+        <div id="apiInfoBody" class="api-info-body"></div>
+        <div class="modal-footer">
+          <button type="button" class="btn" id="apiInfoCloseBtn">Close</button>
+        </div>
       </div>
     </div>
     <!-- =============================================================================

--- a/js/api.js
+++ b/js/api.js
@@ -1,6 +1,14 @@
 // API INTEGRATION FUNCTIONS
 // =============================================================================
 
+// Track provider connection status for settings UI
+const providerStatuses = {
+  METALS_DEV: "disconnected",
+  METALS_API: "disconnected",
+  METAL_PRICE_API: "disconnected",
+  CUSTOM: "disconnected",
+};
+
 /**
  * Loads API configuration from localStorage
  * @returns {Object|null} API configuration or null if not set
@@ -10,16 +18,37 @@ const loadApiConfig = () => {
     const stored = localStorage.getItem(API_KEY_STORAGE_KEY);
     if (stored) {
       const config = JSON.parse(stored);
-      // Simple decryption (base64 decode)
-      if (config.apiKey) {
-        config.apiKey = atob(config.apiKey);
+      if (config.keys) {
+        Object.keys(config.keys).forEach((p) => {
+          if (config.keys[p]) {
+            config.keys[p] = atob(config.keys[p]);
+          }
+        });
+      } else if (config.apiKey && config.provider) {
+        // Legacy format migration
+        config.keys = { [config.provider]: atob(config.apiKey) };
       }
-      return config;
+      return {
+        provider: config.provider || "",
+        keys: config.keys || {},
+        cacheHours:
+          typeof config.cacheHours === "number" ? config.cacheHours : 24,
+        custom: {
+          baseUrl: config.custom?.baseUrl || "",
+          endpoint: config.custom?.endpoint || "",
+          metalFormat: config.custom?.metalFormat || "word",
+        },
+      };
     }
   } catch (error) {
-    console.error('Error loading API config:', error);
+    console.error("Error loading API config:", error);
   }
-  return null;
+  return {
+    provider: "",
+    keys: {},
+    cacheHours: 24,
+    custom: { baseUrl: "", endpoint: "", metalFormat: "word" },
+  };
 };
 
 /**
@@ -28,16 +57,27 @@ const loadApiConfig = () => {
  */
 const saveApiConfig = (config) => {
   try {
-    // Simple encryption (base64 encode)
-    const configToSave = { ...config };
-    if (configToSave.apiKey) {
-      configToSave.apiKey = btoa(configToSave.apiKey);
-    }
+    const configToSave = {
+      provider: config.provider || "",
+      keys: {},
+      cacheHours:
+        typeof config.cacheHours === "number" ? config.cacheHours : 24,
+      custom: {
+        baseUrl: config.custom?.baseUrl || "",
+        endpoint: config.custom?.endpoint || "",
+        metalFormat: config.custom?.metalFormat || "word",
+      },
+    };
+    Object.keys(config.keys || {}).forEach((p) => {
+      if (config.keys[p]) {
+        configToSave.keys[p] = btoa(config.keys[p]);
+      }
+    });
     localStorage.setItem(API_KEY_STORAGE_KEY, JSON.stringify(configToSave));
     apiConfig = config;
-    updateApiStatus();
+    updateSyncButtonStates();
   } catch (error) {
-    console.error('Error saving API config:', error);
+    console.error("Error saving API config:", error);
   }
 };
 
@@ -47,9 +87,16 @@ const saveApiConfig = (config) => {
 const clearApiConfig = () => {
   localStorage.removeItem(API_KEY_STORAGE_KEY);
   localStorage.removeItem(API_CACHE_KEY);
-  apiConfig = null;
+  apiConfig = {
+    provider: "",
+    keys: {},
+    cacheHours: 24,
+    custom: { baseUrl: "", endpoint: "", metalFormat: "word" },
+  };
   apiCache = null;
-  updateApiStatus();
+  Object.keys(providerStatuses).forEach((p) =>
+    setProviderStatus(p, "disconnected"),
+  );
   updateSyncButtonStates();
 };
 
@@ -59,8 +106,92 @@ const clearApiConfig = () => {
 const clearApiCache = () => {
   localStorage.removeItem(API_CACHE_KEY);
   apiCache = null;
-  updateApiStatus();
-  alert('API cache cleared. Next sync will pull fresh data from the API.');
+  alert("API cache cleared. Next sync will pull fresh data from the API.");
+};
+
+/**
+ * Gets cache duration in milliseconds
+ * @returns {number} Cache duration
+ */
+const getCacheDurationMs = () => {
+  const hours = apiConfig?.cacheHours ?? 24;
+  return hours * 60 * 60 * 1000;
+};
+
+/**
+ * Sets connection status for a provider in the settings UI
+ * @param {string} provider
+ * @param {"connected"|"disconnected"|"error"} status
+ */
+const setProviderStatus = (provider, status) => {
+  providerStatuses[provider] = status;
+  const block = document.querySelector(
+    `.api-provider[data-provider="${provider}"] .provider-status`,
+  );
+  if (!block) return;
+  block.classList.remove(
+    "status-connected",
+    "status-disconnected",
+    "status-error",
+  );
+  block.classList.add(`status-${status}`);
+  const text = block.querySelector(".status-text");
+  if (text) {
+    text.textContent =
+      status === "connected"
+        ? "Connected"
+        : status === "error"
+          ? "Error"
+          : "Disconnected";
+  }
+};
+
+/**
+ * Updates default provider selection in config
+ * @param {string} provider
+ */
+const setDefaultProvider = (provider) => {
+  const config = loadApiConfig();
+  config.provider = provider;
+  saveApiConfig(config);
+  updateSyncButtonStates();
+};
+
+/**
+ * Clears stored API key for a provider
+ * @param {string} provider
+ */
+const clearApiKey = (provider) => {
+  const config = loadApiConfig();
+  delete config.keys[provider];
+  if (provider === "CUSTOM") {
+    config.custom = { baseUrl: "", endpoint: "", metalFormat: "word" };
+    const baseUrlInput = document.getElementById("customBaseUrl");
+    const endpointInput = document.getElementById("customEndpoint");
+    const formatSelect = document.getElementById("customMetalFormat");
+    const display = document.getElementById("customBaseUrlDisplay");
+    if (baseUrlInput) baseUrlInput.value = "";
+    if (endpointInput) endpointInput.value = "";
+    if (formatSelect) formatSelect.value = "word";
+    if (display) display.textContent = "User-defined";
+  }
+  saveApiConfig(config);
+  const input = document.getElementById(`apiKey_${provider}`);
+  if (input) input.value = "";
+  setProviderStatus(provider, "disconnected");
+};
+
+/**
+ * Updates cache duration setting
+ * @param {number} hours
+ */
+const setCacheDuration = (hours) => {
+  const config = loadApiConfig();
+  config.cacheHours = hours;
+  saveApiConfig(config);
+  if (hours === 0) {
+    clearApiCache();
+  }
 };
 
 /**
@@ -75,18 +206,28 @@ const refreshFromCache = () => {
 
   let updatedCount = 0;
   Object.entries(cache.data).forEach(([metal, price]) => {
-    const metalConfig = Object.values(METALS).find(m => m.key === metal);
+    const metalConfig = Object.values(METALS).find((m) => m.key === metal);
     if (metalConfig && price > 0) {
       // Save to localStorage
       localStorage.setItem(metalConfig.spotKey, price.toString());
       spotPrices[metal] = price;
-      
+
       // Update display
       elements.spotPriceDisplay[metal].textContent = formatDollar(price);
-      
+
       // Record in history as 'cached' to distinguish from fresh API calls
-      recordSpot(price, 'cached', metalConfig.name);
-      
+      recordSpot(
+        price,
+        "cached",
+        metalConfig.name,
+        API_PROVIDERS[cache.provider]?.name,
+      );
+
+      const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
+      if (ts) {
+        ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+      }
+
       updatedCount++;
     }
   });
@@ -96,7 +237,7 @@ const refreshFromCache = () => {
     updateSummary();
     return true;
   }
-  
+
   return false;
 };
 
@@ -110,9 +251,9 @@ const loadApiCache = () => {
     if (stored) {
       const cache = JSON.parse(stored);
       const now = new Date().getTime();
-      
-      // Check if cache is still valid (within 24 hours)
-      if (cache.timestamp && (now - cache.timestamp) < API_CACHE_DURATION) {
+
+      const duration = getCacheDurationMs();
+      if (cache.timestamp && now - cache.timestamp < duration) {
         return cache;
       } else {
         // Cache expired, remove it
@@ -120,7 +261,7 @@ const loadApiCache = () => {
       }
     }
   } catch (error) {
-    console.error('Error loading API cache:', error);
+    console.error("Error loading API cache:", error);
   }
   return null;
 };
@@ -129,17 +270,23 @@ const loadApiCache = () => {
  * Saves API data to cache
  * @param {Object} data - Data to cache
  */
-const saveApiCache = (data) => {
+const saveApiCache = (data, provider) => {
   try {
+    const duration = getCacheDurationMs();
+    if (duration === 0) {
+      localStorage.removeItem(API_CACHE_KEY);
+      apiCache = null;
+      return;
+    }
     const cacheObject = {
       timestamp: new Date().getTime(),
-      data: data
+      data: data,
+      provider,
     };
     localStorage.setItem(API_CACHE_KEY, JSON.stringify(cacheObject));
     apiCache = cacheObject;
-    updateApiStatus();
   } catch (error) {
-    console.error('Error saving API cache:', error);
+    console.error("Error saving API cache:", error);
   }
 };
 
@@ -152,57 +299,91 @@ const saveApiCache = (data) => {
 const fetchSpotPricesFromApi = async (provider, apiKey) => {
   const providerConfig = API_PROVIDERS[provider];
   if (!providerConfig) {
-    throw new Error('Invalid API provider');
+    throw new Error("Invalid API provider");
   }
 
   const results = {};
   const errors = [];
 
   // Fetch prices for each metal
-  for (const [metal, endpoint] of Object.entries(providerConfig.endpoints)) {
-    try {
-      const url = `${providerConfig.baseUrl}${endpoint.replace('{API_KEY}', apiKey)}`;
-      
-      // Use different headers based on provider
-      const headers = {
-        'Content-Type': 'application/json'
-      };
-      
-      // Some providers use API key in header instead of URL
-      if (provider === 'METALS_DEV' && apiKey) {
-        headers['Authorization'] = `Bearer ${apiKey}`;
+  if (provider === "CUSTOM") {
+    const { baseUrl, endpoint, metalFormat } = apiConfig.custom || {};
+    const codeMap = {
+      silver: metalFormat === "symbol" ? "XAG" : "silver",
+      gold: metalFormat === "symbol" ? "XAU" : "gold",
+      platinum: metalFormat === "symbol" ? "XPT" : "platinum",
+      palladium: metalFormat === "symbol" ? "XPD" : "palladium",
+    };
+    for (const metal of Object.keys(codeMap)) {
+      try {
+        const url = `${baseUrl}${endpoint
+          .replace("{API_KEY}", apiKey)
+          .replace("{METAL}", codeMap[metal])}`;
+        const response = await fetch(url, {
+          method: "GET",
+          headers: { "Content-Type": "application/json" },
+          mode: "cors",
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        const data = await response.json();
+        const price = providerConfig.parseResponse(data, metal);
+        if (price && price > 0) {
+          results[metal] = price;
+        } else {
+          errors.push(`${metal}: Invalid price data`);
+        }
+      } catch (error) {
+        errors.push(`${metal}: ${error.message}`);
       }
+    }
+  } else {
+    for (const [metal, endpoint] of Object.entries(providerConfig.endpoints)) {
+      try {
+        const url = `${providerConfig.baseUrl}${endpoint.replace("{API_KEY}", apiKey)}`;
 
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: headers,
-        mode: 'cors'
-      });
+        // Use different headers based on provider
+        const headers = {
+          "Content-Type": "application/json",
+        };
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        // Some providers use API key in header instead of URL
+        if (provider === "METALS_DEV" && apiKey) {
+          headers["Authorization"] = `Bearer ${apiKey}`;
+        }
+
+        const response = await fetch(url, {
+          method: "GET",
+          headers: headers,
+          mode: "cors",
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        const price = providerConfig.parseResponse(data, metal);
+
+        if (price && price > 0) {
+          results[metal] = price;
+        } else {
+          errors.push(`${metal}: Invalid price data`);
+        }
+      } catch (error) {
+        errors.push(`${metal}: ${error.message}`);
       }
-
-      const data = await response.json();
-      const price = providerConfig.parseResponse(data, metal);
-      
-      if (price && price > 0) {
-        results[metal] = price;
-      } else {
-        errors.push(`${metal}: Invalid price data`);
-      }
-    } catch (error) {
-      errors.push(`${metal}: ${error.message}`);
     }
   }
 
   if (Object.keys(results).length === 0) {
-    throw new Error(`No valid prices retrieved. Errors: ${errors.join(', ')}`);
+    throw new Error(`No valid prices retrieved. Errors: ${errors.join(", ")}`);
   }
 
   // If we got some results but not all, show a warning
   if (errors.length > 0) {
-    console.warn('Some metals failed to fetch:', errors);
+    console.warn("Some metals failed to fetch:", errors);
   }
 
   return results;
@@ -214,10 +395,27 @@ const fetchSpotPricesFromApi = async (provider, apiKey) => {
  * @param {boolean} forceSync - Whether to force sync even if cache is valid
  * @returns {Promise<boolean>} Promise resolving to success status
  */
-const syncSpotPricesFromApi = async (showProgress = true, forceSync = false) => {
-  if (!apiConfig || !apiConfig.provider || !apiConfig.apiKey) {
-    alert('No API configuration found. Please configure an API provider first.');
+const syncSpotPricesFromApi = async (
+  showProgress = true,
+  forceSync = false,
+) => {
+  if (
+    !apiConfig ||
+    !apiConfig.provider ||
+    !apiConfig.keys[apiConfig.provider]
+  ) {
+    alert(
+      "No API configuration found. Please configure an API provider first.",
+    );
     return false;
+  }
+
+  if (apiConfig.provider === "CUSTOM") {
+    const { baseUrl, endpoint } = apiConfig.custom || {};
+    if (!baseUrl || !endpoint) {
+      alert("Custom provider configuration incomplete.");
+      return false;
+    }
   }
 
   // Check cache age if not forcing sync
@@ -226,17 +424,22 @@ const syncSpotPricesFromApi = async (showProgress = true, forceSync = false) => 
     if (cache && cache.data && cache.timestamp) {
       const now = new Date().getTime();
       const cacheAge = now - cache.timestamp;
-      
-      // If cache is less than 24 hours old, use cached data instead of API call
-      if (cacheAge < API_CACHE_DURATION) {
+      const duration = getCacheDurationMs();
+
+      if (cacheAge < duration) {
         if (showProgress) {
           const hoursAgo = Math.floor(cacheAge / (1000 * 60 * 60));
           const minutesAgo = Math.floor(cacheAge / (1000 * 60));
-          const timeText = hoursAgo > 0 ? `${hoursAgo} hours ago` : `${minutesAgo} minutes ago`;
-          
-          alert(`Using cached prices from ${timeText}. To pull fresh data from the API, go to the API configuration and clear the cache first.`);
+          const timeText =
+            hoursAgo > 0
+              ? `${hoursAgo} hours ago`
+              : `${minutesAgo} minutes ago`;
+
+          alert(
+            `Using cached prices from ${timeText}. To pull fresh data from the API, go to the API configuration and clear the cache first.`,
+          );
         }
-        
+
         // Use cached data to refresh display
         return refreshFromCache();
       }
@@ -248,44 +451,63 @@ const syncSpotPricesFromApi = async (showProgress = true, forceSync = false) => 
   }
 
   try {
-    const spotPricesData = await fetchSpotPricesFromApi(apiConfig.provider, apiConfig.apiKey);
-    
+    const spotPricesData = await fetchSpotPricesFromApi(
+      apiConfig.provider,
+      apiConfig.keys[apiConfig.provider],
+    );
+
     // Update spot prices in the application
     let updatedCount = 0;
     Object.entries(spotPricesData).forEach(([metal, price]) => {
-      const metalConfig = Object.values(METALS).find(m => m.key === metal);
+      const metalConfig = Object.values(METALS).find((m) => m.key === metal);
       if (metalConfig && price > 0) {
         // Save to localStorage
         localStorage.setItem(metalConfig.spotKey, price.toString());
         spotPrices[metal] = price;
-        
+
         // Update display
         elements.spotPriceDisplay[metal].textContent = formatDollar(price);
-        
+
         // Record in history
-        recordSpot(price, 'api', metalConfig.name);
-        
+        recordSpot(
+          price,
+          "api",
+          metalConfig.name,
+          API_PROVIDERS[apiConfig.provider].name,
+        );
+
+        const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
+        if (ts) {
+          ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+        }
+
         updatedCount++;
       }
     });
 
     if (updatedCount > 0) {
       // Save to cache
-      saveApiCache(spotPricesData);
-      
+      saveApiCache(spotPricesData, apiConfig.provider);
+
       // Update summary calculations
       updateSummary();
-      
+
+      setProviderStatus(apiConfig.provider, "connected");
+
       if (showProgress) {
-        alert(`Successfully synced ${updatedCount} metal prices from ${API_PROVIDERS[apiConfig.provider].name}`);
+        alert(
+          `Successfully synced ${updatedCount} metal prices from ${API_PROVIDERS[apiConfig.provider].name}`,
+        );
       }
-      
+
       return true;
     } else {
-      throw new Error('No valid prices were retrieved from API');
+      setProviderStatus(apiConfig.provider, "error");
+      throw new Error("No valid prices were retrieved from API");
     }
   } catch (error) {
-    console.error('API sync error:', error);
+    console.error("API sync error:", error);
+    setProviderStatus(apiConfig.provider, "error");
     if (showProgress) {
       alert(`Failed to sync prices: ${error.message}`);
     }
@@ -308,24 +530,33 @@ const testApiConnection = async (provider, apiKey) => {
     // Just test one metal (silver) to verify connection
     const providerConfig = API_PROVIDERS[provider];
     if (!providerConfig) {
-      throw new Error('Invalid provider');
+      throw new Error("Invalid provider");
     }
 
-    const endpoint = providerConfig.endpoints.silver;
-    const url = `${providerConfig.baseUrl}${endpoint.replace('{API_KEY}', apiKey)}`;
-    
+    let url = "";
+    if (provider === "CUSTOM") {
+      const { baseUrl, endpoint, metalFormat } = apiConfig.custom || {};
+      const metalParam = metalFormat === "symbol" ? "XAG" : "silver";
+      url = `${baseUrl}${endpoint
+        .replace("{API_KEY}", apiKey)
+        .replace("{METAL}", metalParam)}`;
+    } else {
+      const endpoint = providerConfig.endpoints.silver;
+      url = `${providerConfig.baseUrl}${endpoint.replace("{API_KEY}", apiKey)}`;
+    }
+
     const headers = {
-      'Content-Type': 'application/json'
+      "Content-Type": "application/json",
     };
-    
-    if (provider === 'METALS_DEV' && apiKey) {
-      headers['Authorization'] = `Bearer ${apiKey}`;
+
+    if (provider === "METALS_DEV" && apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
     }
 
     const response = await fetch(url, {
-      method: 'GET',
+      method: "GET",
       headers: headers,
-      mode: 'cors'
+      mode: "cors",
     });
 
     if (!response.ok) {
@@ -333,12 +564,102 @@ const testApiConnection = async (provider, apiKey) => {
     }
 
     const data = await response.json();
-    const price = providerConfig.parseResponse(data, 'silver');
-    
+    const price = providerConfig.parseResponse(data, "silver");
+
     return price && price > 0;
   } catch (error) {
-    console.error('API connection test failed:', error);
+    console.error("API connection test failed:", error);
     return false;
+  }
+};
+
+/**
+ * Handles testing and syncing for a specific provider
+ * @param {string} provider - Provider key
+ */
+const handleProviderSync = async (provider) => {
+  const keyInput = document.getElementById(`apiKey_${provider}`);
+  const radio = document.querySelector(
+    `input[name="defaultProvider"][value="${provider}"]`,
+  );
+  if (!keyInput) return;
+
+  const apiKey = keyInput.value.trim();
+  if (!apiKey) {
+    alert("Please enter your API key");
+    return;
+  }
+
+  // Save configuration
+  const config = loadApiConfig();
+  config.keys[provider] = apiKey;
+  if (provider === "CUSTOM") {
+    const baseUrl = document.getElementById("customBaseUrl")?.value.trim();
+    const endpoint = document.getElementById("customEndpoint")?.value.trim();
+    const metalFormat =
+      document.getElementById("customMetalFormat")?.value || "word";
+    if (!baseUrl || !endpoint) {
+      alert("Please enter base URL and endpoint for custom provider");
+      return;
+    }
+    config.custom = { baseUrl, endpoint, metalFormat };
+    const display = document.getElementById("customBaseUrlDisplay");
+    if (display) display.textContent = baseUrl;
+  }
+  if (radio && radio.checked) {
+    config.provider = provider;
+  }
+  config.timestamp = new Date().getTime();
+  saveApiConfig(config);
+  updateSyncButtonStates();
+  setProviderStatus(provider, "disconnected");
+
+  // Test connection
+  const ok = await testApiConnection(provider, apiKey);
+  if (!ok) {
+    alert("API connection test failed.");
+    setProviderStatus(provider, "error");
+    return;
+  }
+
+  try {
+    const data = await fetchSpotPricesFromApi(provider, apiKey);
+    let updatedCount = 0;
+    Object.entries(data).forEach(([metal, price]) => {
+      const metalConfig = Object.values(METALS).find((m) => m.key === metal);
+      if (metalConfig && price > 0) {
+        localStorage.setItem(metalConfig.spotKey, price.toString());
+        spotPrices[metal] = price;
+        elements.spotPriceDisplay[metal].textContent = formatDollar(price);
+        recordSpot(
+          price,
+          "api",
+          metalConfig.name,
+          API_PROVIDERS[provider].name,
+        );
+        const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
+        if (ts) {
+          ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+        }
+        updatedCount++;
+      }
+    });
+
+    if (updatedCount > 0) {
+      saveApiCache(data, provider);
+      updateSummary();
+      setProviderStatus(provider, "connected");
+      alert(
+        `Successfully synced ${updatedCount} metal prices from ${API_PROVIDERS[provider].name}`,
+      );
+    } else {
+      setProviderStatus(provider, "error");
+      alert("No valid prices retrieved from API");
+    }
+  } catch (error) {
+    console.error("API sync error:", error);
+    setProviderStatus(provider, "error");
+    alert("Failed to sync prices: " + error.message);
   }
 };
 
@@ -347,16 +668,19 @@ const testApiConnection = async (provider, apiKey) => {
  * @param {boolean} syncing - Whether sync is in progress
  */
 const updateSyncButtonStates = (syncing = false) => {
-  const hasApi = apiConfig && apiConfig.provider && apiConfig.apiKey;
-  
-  Object.values(METALS).forEach(metalConfig => {
+  const hasApi =
+    apiConfig && apiConfig.provider && apiConfig.keys[apiConfig.provider];
+
+  Object.values(METALS).forEach((metalConfig) => {
     const syncBtn = document.getElementById(`syncBtn${metalConfig.name}`);
     if (syncBtn) {
       syncBtn.disabled = !hasApi || syncing;
-      syncBtn.textContent = syncing ? '...' : 'Sync';
-      syncBtn.title = hasApi 
-        ? (syncing ? 'Syncing...' : 'Sync from API') 
-        : 'Configure API first';
+      syncBtn.textContent = syncing ? "..." : "Sync";
+      syncBtn.title = hasApi
+        ? syncing
+          ? "Syncing..."
+          : "Sync from API"
+        : "Configure API first";
     }
   });
 };
@@ -364,186 +688,151 @@ const updateSyncButtonStates = (syncing = false) => {
 /**
  * Updates API status display in modal
  */
-const updateApiStatus = () => {
-  const statusDisplay = document.getElementById('apiStatusDisplay');
-  const statusText = document.getElementById('apiStatusText');
-  const cacheInfo = document.getElementById('apiCacheInfo');
-  
-  if (!statusDisplay || !statusText) return;
-
-  // Reset classes
-  statusDisplay.className = '';
-  statusDisplay.style.cssText = statusDisplay.style.cssText.replace(/background[^;]*;?/g, '');
-  statusDisplay.style.cssText = statusDisplay.style.cssText.replace(/border-color[^;]*;?/g, '');
-
-  if (apiConfig && apiConfig.provider) {
-    statusText.textContent = `Connected to ${API_PROVIDERS[apiConfig.provider].name}`;
-    statusDisplay.classList.add('api-status-connected');
-    
-    if (cacheInfo && apiCache && apiCache.timestamp) {
-      const cacheAge = new Date().getTime() - apiCache.timestamp;
-      const hoursAgo = Math.floor(cacheAge / (1000 * 60 * 60));
-      const minutesAgo = Math.floor(cacheAge / (1000 * 60));
-      
-      if (hoursAgo > 0) {
-        cacheInfo.textContent = `Last synced: ${hoursAgo} hours ago`;
-      } else if (minutesAgo > 0) {
-        cacheInfo.textContent = `Last synced: ${minutesAgo} minutes ago`;
-      } else {
-        cacheInfo.textContent = 'Just synced';
-      }
-    } else if (cacheInfo) {
-      cacheInfo.textContent = 'No cached data';
-    }
-  } else {
-    statusText.textContent = 'No API configured';
-    if (cacheInfo) {
-      cacheInfo.textContent = '';
-    }
-  }
-};
-
 /**
- * Shows API configuration modal
+ * Shows settings modal and populates API fields
  */
-const showApiModal = () => {
-  // Re-query the DOM in case the cached element wasn't populated yet
-  const modal = document.getElementById('apiModal');
+const showSettingsModal = () => {
+  const modal = document.getElementById("settingsModal");
   if (!modal) return;
-
-  // Ensure future calls have a valid reference
-  elements.apiModal = modal;
-
-  // Load current configuration
-  const currentConfig = loadApiConfig();
-  
-  if (currentConfig) {
-    const providerSelect = document.getElementById('apiProvider');
-    const apiKeyInput = document.getElementById('apiKey');
-    
-    if (providerSelect) providerSelect.value = currentConfig.provider || '';
-    if (apiKeyInput) apiKeyInput.value = currentConfig.apiKey || '';
-    
-    // Update provider info
-    updateProviderInfo(currentConfig.provider);
-  }
-  
-  // Update status display
-  updateApiStatus();
-  
-  modal.style.display = 'flex';
-};
-
-/**
- * Hides API configuration modal
- */
-const hideApiModal = () => {
-  const modal = document.getElementById('apiModal');
-  if (modal) {
-    modal.style.display = 'none';
-  }
-};
-
-// Make API modal controls available globally
-window.showApiModal = showApiModal;
-window.hideApiModal = hideApiModal;
-
-/**
- * Updates provider information panel in modal
- * @param {string} providerKey - Provider key
- */
-const updateProviderInfo = (providerKey) => {
-  const providerInfo = document.getElementById('providerInfo');
-  const providerDetails = document.getElementById('providerDetails');
-  const providerDocs = document.getElementById('providerDocs');
-  
-  if (!providerInfo || !providerDetails || !providerDocs) return;
-
-  if (providerKey && API_PROVIDERS[providerKey]) {
-    const provider = API_PROVIDERS[providerKey];
-    providerInfo.style.display = 'block';
-    providerDetails.innerHTML = `
-      <strong>${provider.name}</strong><br>
-      Base URL: ${provider.baseUrl}<br>
-      Metals: Silver, Gold, Platinum, Palladium<br>
-      <br>
-      <strong>📋 API Key Management:</strong><br>
-      • Visit the documentation link below to manage your API key<br>
-      • You can view usage, reset, or regenerate your key there<br>
-      • Keep your API key secure and never share it publicly
-    `;
-    providerDocs.href = provider.documentation;
-    providerDocs.innerHTML = `📄 ${provider.name} Documentation & Key Management`;
-    providerDocs.title = `Visit ${provider.name} to manage your API key, view usage, and access documentation`;
-  } else {
-    providerInfo.style.display = 'none';
-  }
-};
-
-/**
- * Handles API configuration form submission
- * @param {Event} event - Form submit event
- */
-const handleApiConfigSubmit = async (event) => {
-  event.preventDefault();
-  
-  const providerSelect = document.getElementById('apiProvider');
-  const apiKeyInput = document.getElementById('apiKey');
-  const testConnection = document.getElementById('testConnection');
-  
-  if (!providerSelect || !apiKeyInput) return;
-
-  const provider = providerSelect.value;
-  const apiKey = apiKeyInput.value.trim();
-
-  if (!provider) {
-    alert('Please select an API provider');
-    return;
-  }
-
-  if (!apiKey) {
-    alert('Please enter your API key');
-    return;
-  }
-
-  // Test connection if requested
-  if (testConnection && testConnection.checked) {
-    const saveBtn = document.getElementById('apiSaveBtn');
-    if (saveBtn) {
-      saveBtn.textContent = 'Testing...';
-      saveBtn.disabled = true;
-    }
-
-    try {
-      const connectionOk = await testApiConnection(provider, apiKey);
-      if (!connectionOk) {
-        alert('API connection test failed. Please check your API key and try again.');
-        return;
-      }
-    } catch (error) {
-      alert(`Connection test failed: ${error.message}`);
-      return;
-    } finally {
-      if (saveBtn) {
-        saveBtn.textContent = 'Save & Test';
-        saveBtn.disabled = false;
-      }
-    }
-  }
-
-  // Save configuration
-  const config = {
-    provider: provider,
-    apiKey: apiKey,
-    timestamp: new Date().getTime()
+  let currentConfig = loadApiConfig() || {
+    provider: "",
+    keys: {},
+    cacheHours: 24,
   };
+  if (!currentConfig.provider) {
+    currentConfig.provider = Object.keys(API_PROVIDERS)[0];
+    saveApiConfig(currentConfig);
+  }
 
-  saveApiConfig(config);
-  updateSyncButtonStates();
-  
-  alert('API configuration saved successfully!');
-  hideApiModal();
+  const savedTheme = localStorage.getItem(THEME_KEY);
+  const themeValue = savedTheme ? savedTheme : "system";
+  const themeRadio = document.querySelector(
+    `input[name="themePreference"][value="${themeValue}"]`,
+  );
+  if (themeRadio) themeRadio.checked = true;
+
+  Object.keys(API_PROVIDERS).forEach((prov) => {
+    const input = document.getElementById(`apiKey_${prov}`);
+    const radio = document.querySelector(
+      `input[name="defaultProvider"][value="${prov}"]`,
+    );
+    if (input) input.value = currentConfig.keys?.[prov] || "";
+    if (radio) radio.checked = currentConfig.provider === prov;
+    setProviderStatus(prov, providerStatuses[prov] || "disconnected");
+    if (prov === "CUSTOM") {
+      const baseUrl = document.getElementById("customBaseUrl");
+      const endpoint = document.getElementById("customEndpoint");
+      const format = document.getElementById("customMetalFormat");
+      const display = document.getElementById("customBaseUrlDisplay");
+      if (baseUrl) baseUrl.value = currentConfig.custom?.baseUrl || "";
+      if (endpoint) endpoint.value = currentConfig.custom?.endpoint || "";
+      if (format) format.value = currentConfig.custom?.metalFormat || "word";
+      if (display)
+        display.textContent = currentConfig.custom?.baseUrl || "User-defined";
+    }
+  });
+
+  const durationSelect = document.getElementById("apiCacheDuration");
+  if (durationSelect) {
+    durationSelect.value = String(currentConfig.cacheHours ?? 24);
+  }
+
+  modal.style.display = "flex";
 };
+
+/**
+ * Hides settings modal
+ */
+const hideSettingsModal = () => {
+  const modal = document.getElementById("settingsModal");
+  if (modal) {
+    modal.style.display = "none";
+  }
+};
+
+/**
+ * Shows provider information modal
+ * @param {string} providerKey
+ */
+const showProviderInfo = (providerKey) => {
+  const modal = document.getElementById("apiInfoModal");
+  if (!modal || !API_PROVIDERS[providerKey]) return;
+
+  const provider = API_PROVIDERS[providerKey];
+  const title = document.getElementById("apiInfoTitle");
+  const body = document.getElementById("apiInfoBody");
+
+  if (title) title.textContent = "Provider Information";
+  if (body) {
+    if (providerKey === "CUSTOM") {
+      const cfg = loadApiConfig();
+      const custom = cfg.custom || {};
+      body.innerHTML = `
+        <div class="info-provider-name">${provider.name}</div>
+        <div>Base URL: ${custom.baseUrl || "Not set"}</div>
+        <div>Endpoint: ${custom.endpoint || "Not set"}</div>
+        <div>Metal parameter: ${
+          custom.metalFormat === "symbol"
+            ? "Symbol (XAG, XAU, XPT, XPD)"
+            : "Word (silver, gold, etc.)"
+        }</div>
+        <div class="api-key-info">
+          <div>📋 <strong>API Key Management:</strong></div>
+          <ul>
+            <li>Endpoint must return JSON containing a price field.</li>
+            <li>Use {API_KEY} and {METAL} placeholders in endpoint.</li>
+            <li>Keep your API key secure and never share it publicly</li>
+          </ul>
+        </div>
+      `;
+    } else {
+      body.innerHTML = `
+        <div class="info-provider-name">${provider.name}</div>
+        <div>Base URL: ${provider.baseUrl}</div>
+        <div>Metals: Silver, Gold, Platinum, Palladium</div>
+        <div class="api-key-info">
+          <div>📋 <strong>API Key Management:</strong></div>
+          <ul>
+            <li>Visit the documentation link below to manage your API key</li>
+            <li>You can view usage, reset, or regenerate your key there</li>
+            <li>Keep your API key secure and never share it publicly</li>
+          </ul>
+        </div>
+        ${
+          provider.documentation
+            ? `<a class="btn info-docs-btn" href="${provider.documentation}" target="_blank" rel="noopener">
+        📄 ${provider.name} Documentation & Key Management
+      </a>`
+            : ""
+        }
+      `;
+    }
+  }
+
+  modal.style.display = "flex";
+};
+
+/**
+ * Hides provider information modal
+ */
+const hideProviderInfo = () => {
+  const modal = document.getElementById("apiInfoModal");
+  if (modal) {
+    modal.style.display = "none";
+  }
+};
+
+// Make modal controls available globally
+window.showSettingsModal = showSettingsModal;
+window.hideSettingsModal = hideSettingsModal;
+window.showProviderInfo = showProviderInfo;
+window.hideProviderInfo = hideProviderInfo;
+
+window.handleProviderSync = handleProviderSync;
+window.clearApiKey = clearApiKey;
+window.clearApiCache = clearApiCache;
+window.setDefaultProvider = setDefaultProvider;
+window.setCacheDuration = setCacheDuration;
 
 /**
  * Shows manual price input for a specific metal
@@ -552,8 +841,8 @@ const handleApiConfigSubmit = async (event) => {
 const showManualInput = (metal) => {
   const manualInput = document.getElementById(`manualInput${metal}`);
   if (manualInput) {
-    manualInput.style.display = 'block';
-    
+    manualInput.style.display = "block";
+
     // Focus the input field
     const input = document.getElementById(`userSpotPrice${metal}`);
     if (input) {
@@ -569,12 +858,12 @@ const showManualInput = (metal) => {
 const hideManualInput = (metal) => {
   const manualInput = document.getElementById(`manualInput${metal}`);
   if (manualInput) {
-    manualInput.style.display = 'none';
-    
+    manualInput.style.display = "none";
+
     // Clear the input
     const input = document.getElementById(`userSpotPrice${metal}`);
     if (input) {
-      input.value = '';
+      input.value = "";
     }
   }
 };
@@ -584,31 +873,34 @@ const hideManualInput = (metal) => {
  * @param {string} metal - Metal name (Silver, Gold, etc.)
  */
 const resetSpotPrice = (metal) => {
-  const metalConfig = Object.values(METALS).find(m => m.name === metal);
+  const metalConfig = Object.values(METALS).find((m) => m.name === metal);
   if (!metalConfig) return;
 
   let resetPrice = metalConfig.defaultPrice;
-  let source = 'default';
+  let source = "default";
+  let providerName = null;
 
   // If we have cached API data, use that instead
   if (apiCache && apiCache.data && apiCache.data[metalConfig.key]) {
     resetPrice = apiCache.data[metalConfig.key];
-    source = 'api';
+    source = "api";
+    providerName = API_PROVIDERS[apiCache.provider]?.name || null;
   }
 
   // Update price
   localStorage.setItem(metalConfig.spotKey, resetPrice.toString());
   spotPrices[metalConfig.key] = resetPrice;
-  
+
   // Update display
-  elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(resetPrice);
-  
+  elements.spotPriceDisplay[metalConfig.key].textContent =
+    formatDollar(resetPrice);
+
   // Record in history
-  recordSpot(resetPrice, source, metalConfig.name);
-  
+  recordSpot(resetPrice, source, metalConfig.name, providerName);
+
   // Update summary
   updateSummary();
-  
+
   // Hide manual input if shown
   hideManualInput(metal);
 };
@@ -623,14 +915,19 @@ const createBackupData = () => {
     timestamp: new Date().toISOString(),
     inventory: loadData(LS_KEY, []),
     spotHistory: loadData(SPOT_HISTORY_KEY, []),
-    apiConfig: apiConfig ? {
-      provider: apiConfig.provider,
-      providerName: API_PROVIDERS[apiConfig.provider]?.name || 'Unknown',
-      keyLength: apiConfig.apiKey ? apiConfig.apiKey.length : 0,
-      hasKey: !!apiConfig.apiKey,
-      timestamp: apiConfig.timestamp
-    } : null,
-    spotPrices: { ...spotPrices }
+    apiConfig:
+      apiConfig && apiConfig.provider
+        ? {
+            provider: apiConfig.provider,
+            providerName: API_PROVIDERS[apiConfig.provider]?.name || "Unknown",
+            keyLength: apiConfig.keys[apiConfig.provider]
+              ? apiConfig.keys[apiConfig.provider].length
+              : 0,
+            hasKey: !!apiConfig.keys[apiConfig.provider],
+            timestamp: apiConfig.timestamp,
+          }
+        : null,
+    spotPrices: { ...spotPrices },
   };
 
   return backupData;
@@ -641,53 +938,81 @@ const createBackupData = () => {
  */
 const downloadCompleteBackup = async () => {
   try {
-    const timestamp = new Date().toISOString().slice(0, 19).replace(/[T:]/g, '-');
-    
+    const timestamp = new Date()
+      .toISOString()
+      .slice(0, 19)
+      .replace(/[T:]/g, "-");
+
     // 1. Create inventory CSV using existing export logic
     const inventory = loadData(LS_KEY, []);
     if (inventory.length > 0) {
-      // Create CSV manually for backup instead of calling exportCsv() 
-      const headers = ["Metal","Name","Qty","Type","Weight(oz)","Purchase Price","Spot Price ($/oz)","Premium ($/oz)","Total Premium","Purchase Location","Storage Location","Notes","Date","Collectable"];
-      const sortedInventory = [...inventory].sort((a, b) => new Date(b.date) - new Date(a.date));
-      
-      const rows = sortedInventory.map(item => [
-        item.metal || 'Silver',
+      // Create CSV manually for backup instead of calling exportCsv()
+      const headers = [
+        "Metal",
+        "Name",
+        "Qty",
+        "Type",
+        "Weight(oz)",
+        "Purchase Price",
+        "Spot Price ($/oz)",
+        "Premium ($/oz)",
+        "Total Premium",
+        "Purchase Location",
+        "Storage Location",
+        "Notes",
+        "Date",
+        "Collectable",
+      ];
+      const sortedInventory = [...inventory].sort(
+        (a, b) => new Date(b.date) - new Date(a.date),
+      );
+
+      const rows = sortedInventory.map((item) => [
+        item.metal || "Silver",
         item.name,
         item.qty,
         item.type,
         parseFloat(item.weight).toFixed(4),
         formatDollar(item.price),
-        item.isCollectable ? 'N/A' : formatDollar(item.spotPriceAtPurchase),
-        item.isCollectable ? 'N/A' : formatDollar(item.premiumPerOz),
-        item.isCollectable ? 'N/A' : formatDollar(item.totalPremium),
+        item.isCollectable ? "N/A" : formatDollar(item.spotPriceAtPurchase),
+        item.isCollectable ? "N/A" : formatDollar(item.premiumPerOz),
+        item.isCollectable ? "N/A" : formatDollar(item.totalPremium),
         item.purchaseLocation,
-        item.storageLocation || 'Unknown',
-        item.notes || '',
+        item.storageLocation || "Unknown",
+        item.notes || "",
         item.date,
-        item.isCollectable ? 'Yes' : 'No'
+        item.isCollectable ? "Yes" : "No",
       ]);
-      
+
       const inventoryCsv = Papa.unparse([headers, ...rows]);
-      downloadFile(`inventory-backup-${timestamp}.csv`, inventoryCsv, 'text/csv');
+      downloadFile(
+        `inventory-backup-${timestamp}.csv`,
+        inventoryCsv,
+        "text/csv",
+      );
     }
-    
+
     // 2. Create spot history CSV
     const spotHistory = loadData(SPOT_HISTORY_KEY, []);
     if (spotHistory.length > 0) {
       const historyData = [
-        ['Timestamp', 'Metal', 'Price', 'Source'],
-        ...spotHistory.map(entry => [
+        ["Timestamp", "Metal", "Price", "Source"],
+        ...spotHistory.map((entry) => [
           entry.timestamp,
           entry.metal,
           entry.spot,
-          entry.source
-        ])
+          entry.source,
+        ]),
       ];
-      
+
       const historyCsv = Papa.unparse(historyData);
-      downloadFile(`spot-price-history-${timestamp}.csv`, historyCsv, 'text/csv');
+      downloadFile(
+        `spot-price-history-${timestamp}.csv`,
+        historyCsv,
+        "text/csv",
+      );
     }
-    
+
     // 3. Create complete JSON backup
     const completeBackup = {
       version: APP_VERSION,
@@ -696,19 +1021,29 @@ const downloadCompleteBackup = async () => {
         inventory: inventory,
         spotHistory: spotHistory,
         spotPrices: { ...spotPrices },
-        apiConfig: apiConfig ? {
-          provider: apiConfig.provider,
-          providerName: API_PROVIDERS[apiConfig.provider]?.name || 'Unknown',
-          hasKey: !!apiConfig.apiKey,
-          keyLength: apiConfig.apiKey ? apiConfig.apiKey.length : 0,
-          timestamp: apiConfig.timestamp
-        } : null
-      }
+        apiConfig:
+          apiConfig && apiConfig.provider
+            ? {
+                provider: apiConfig.provider,
+                providerName:
+                  API_PROVIDERS[apiConfig.provider]?.name || "Unknown",
+                hasKey: !!apiConfig.keys[apiConfig.provider],
+                keyLength: apiConfig.keys[apiConfig.provider]
+                  ? apiConfig.keys[apiConfig.provider].length
+                  : 0,
+                timestamp: apiConfig.timestamp,
+              }
+            : null,
+      },
     };
-    
+
     const backupJson = JSON.stringify(completeBackup, null, 2);
-    downloadFile(`complete-backup-${timestamp}.json`, backupJson, 'application/json');
-    
+    downloadFile(
+      `complete-backup-${timestamp}.json`,
+      backupJson,
+      "application/json",
+    );
+
     // 4. Create API documentation and restoration guide
     const backupData = createBackupData();
     const apiInfo = `# Precious Metals Tool - Complete Backup
@@ -724,7 +1059,9 @@ Application Version: ${APP_VERSION}
 4. **backup-info-${timestamp}.md** - This documentation file
 
 ## API Configuration
-${backupData.apiConfig ? `
+${
+  backupData.apiConfig
+    ? `
 - Provider: ${backupData.apiConfig.providerName}
 - Has API Key: ${backupData.apiConfig.hasKey}
 - Key Length: ${backupData.apiConfig.keyLength} characters
@@ -734,20 +1071,26 @@ ${backupData.apiConfig ? `
 After restoring, reconfigure your API key in the API settings.
 
 ### API Key Management
-${API_PROVIDERS[apiConfig?.provider] ? `
+${
+  API_PROVIDERS[apiConfig?.provider]
+    ? `
 **${API_PROVIDERS[apiConfig.provider].name}**
 - Documentation: ${API_PROVIDERS[apiConfig.provider].documentation}
 - If you need to reset your API key, visit the documentation link above
-` : ''}
-` : 'No API configuration found.'}
+`
+    : ""
+}
+`
+    : "No API configuration found."
+}
 
 ## Current Data Summary
 - Inventory Items: ${inventory.length}
 - Spot Price History: ${spotHistory.length} entries
-- Silver Price: ${spotPrices.silver || 'Not set'}
-- Gold Price: ${spotPrices.gold || 'Not set'}
-- Platinum Price: ${spotPrices.platinum || 'Not set'}
-- Palladium Price: ${spotPrices.palladium || 'Not set'}
+- Silver Price: ${spotPrices.silver || "Not set"}
+- Gold Price: ${spotPrices.gold || "Not set"}
+- Platinum Price: ${spotPrices.platinum || "Not set"}
+- Palladium Price: ${spotPrices.palladium || "Not set"}
 
 ## Restoration Instructions
 
@@ -757,14 +1100,15 @@ ${API_PROVIDERS[apiConfig?.provider] ? `
 
 *This backup was created by Precious Metals Inventory Tool v${APP_VERSION}*
 `;
-    
-    downloadFile(`backup-info-${timestamp}.md`, apiInfo, 'text/markdown');
-    
-    alert(`Complete backup created! Downloaded files:\n\n✓ Inventory CSV (${inventory.length} items)\n✓ Spot price history (${spotHistory.length} entries)\n✓ Complete JSON backup\n✓ Documentation & restoration guide\n\nCheck your Downloads folder.`);
-    
+
+    downloadFile(`backup-info-${timestamp}.md`, apiInfo, "text/markdown");
+
+    alert(
+      `Complete backup created! Downloaded files:\n\n✓ Inventory CSV (${inventory.length} items)\n✓ Spot price history (${spotHistory.length} entries)\n✓ Complete JSON backup\n✓ Documentation & restoration guide\n\nCheck your Downloads folder.`,
+    );
   } catch (error) {
-    console.error('Backup error:', error);
-    alert('Error creating backup: ' + error.message);
+    console.error("Backup error:", error);
+    alert("Error creating backup: " + error.message);
   }
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,7 +1,7 @@
 // CONFIGURATION & GLOBAL CONSTANTS
 /**
  * API Provider configurations for metals pricing services
- * 
+ *
  * Each provider configuration contains:
  * @property {string} name - Display name for the provider
  * @property {string} baseUrl - Base API endpoint URL
@@ -11,77 +11,110 @@
  */
 const API_PROVIDERS = {
   METALS_DEV: {
-    name: 'Metals.dev',
-    baseUrl: 'https://api.metals.dev/v1',
+    name: "Metals.dev",
+    baseUrl: "https://api.metals.dev/v1",
     endpoints: {
-      silver: '/metal/spot?api_key={API_KEY}&metal=silver&currency=USD',
-      gold: '/metal/spot?api_key={API_KEY}&metal=gold&currency=USD',
-      platinum: '/metal/spot?api_key={API_KEY}&metal=platinum&currency=USD',
-      palladium: '/metal/spot?api_key={API_KEY}&metal=palladium&currency=USD'
+      silver: "/metal/spot?api_key={API_KEY}&metal=silver&currency=USD",
+      gold: "/metal/spot?api_key={API_KEY}&metal=gold&currency=USD",
+      platinum: "/metal/spot?api_key={API_KEY}&metal=platinum&currency=USD",
+      palladium: "/metal/spot?api_key={API_KEY}&metal=palladium&currency=USD",
     },
     parseResponse: (data) => data.rate?.price || null,
-    documentation: 'https://www.metals.dev/docs'
+    documentation: "https://www.metals.dev/docs",
   },
   METALS_API: {
-    name: 'Metals-API.com',
-    baseUrl: 'https://metals-api.com/api',
+    name: "Metals-API.com",
+    baseUrl: "https://metals-api.com/api",
     endpoints: {
-      silver: '/latest?access_key={API_KEY}&base=USD&symbols=XAG',
-      gold: '/latest?access_key={API_KEY}&base=USD&symbols=XAU',
-      platinum: '/latest?access_key={API_KEY}&base=USD&symbols=XPT',
-      palladium: '/latest?access_key={API_KEY}&base=USD&symbols=XPD'
+      silver: "/latest?access_key={API_KEY}&base=USD&symbols=XAG",
+      gold: "/latest?access_key={API_KEY}&base=USD&symbols=XAU",
+      platinum: "/latest?access_key={API_KEY}&base=USD&symbols=XPT",
+      palladium: "/latest?access_key={API_KEY}&base=USD&symbols=XPD",
     },
     parseResponse: (data, metal) => {
       // Expected format: { "success": true, "rates": { "XAG": 0.04 } }
-      const metalCode = metal === 'silver' ? 'XAG' : metal === 'gold' ? 'XAU' : 
-                       metal === 'platinum' ? 'XPT' : 'XPD';
+      const metalCode =
+        metal === "silver"
+          ? "XAG"
+          : metal === "gold"
+            ? "XAU"
+            : metal === "platinum"
+              ? "XPT"
+              : "XPD";
       const rate = data.rates?.[metalCode];
-      return rate ? (1 / rate) : null; // Convert from metal per USD to USD per ounce
+      return rate ? 1 / rate : null; // Convert from metal per USD to USD per ounce
     },
-    documentation: 'https://metals-api.com/documentation'
+    documentation: "https://metals-api.com/documentation",
   },
   METAL_PRICE_API: {
-    name: 'MetalPriceAPI.com',
-    baseUrl: 'https://api.metalpriceapi.com/v1',
+    name: "MetalPriceAPI.com",
+    baseUrl: "https://api.metalpriceapi.com/v1",
     endpoints: {
-      silver: '/latest?api_key={API_KEY}&base=USD&currencies=XAG',
-      gold: '/latest?api_key={API_KEY}&base=USD&currencies=XAU',
-      platinum: '/latest?api_key={API_KEY}&base=USD&currencies=XPT',
-      palladium: '/latest?api_key={API_KEY}&base=USD&currencies=XPD'
+      silver: "/latest?api_key={API_KEY}&base=USD&currencies=XAG",
+      gold: "/latest?api_key={API_KEY}&base=USD&currencies=XAU",
+      platinum: "/latest?api_key={API_KEY}&base=USD&currencies=XPT",
+      palladium: "/latest?api_key={API_KEY}&base=USD&currencies=XPD",
     },
     parseResponse: (data, metal) => {
       // Expected format: { "success": true, "rates": { "XAG": 0.04 } }
-      const metalCode = metal === 'silver' ? 'XAG' : metal === 'gold' ? 'XAU' : 
-                       metal === 'platinum' ? 'XPT' : 'XPD';
+      const metalCode =
+        metal === "silver"
+          ? "XAG"
+          : metal === "gold"
+            ? "XAU"
+            : metal === "platinum"
+              ? "XPT"
+              : "XPD";
       const rate = data.rates?.[metalCode];
-      return rate ? (1 / rate) : null; // Convert from metal per USD to USD per ounce
+      return rate ? 1 / rate : null; // Convert from metal per USD to USD per ounce
     },
-    documentation: 'https://metalpriceapi.com/documentation'
-  }
+    documentation: "https://metalpriceapi.com/documentation",
+  },
+  CUSTOM: {
+    name: "Custom",
+    baseUrl: "",
+    endpoints: {},
+    parseResponse: (data) => {
+      if (typeof data !== "object" || data === null) return null;
+      const candidates = ["price", "rate", "value"];
+      for (const key of candidates) {
+        const val = data[key];
+        if (typeof val === "number") return val;
+        if (typeof val === "string" && !isNaN(parseFloat(val))) {
+          return parseFloat(val);
+        }
+      }
+      const firstNum = Object.values(data).find((v) => typeof v === "number");
+      return typeof firstNum === "number" ? firstNum : null;
+    },
+    documentation: "",
+  },
 };
 
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = '3.1.12';
+const APP_VERSION = "3.1.12";
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
-const LS_KEY = 'metalInventory';
+const LS_KEY = "metalInventory";
 
 /** @constant {string} SPOT_HISTORY_KEY - LocalStorage key for spot price history */
-const SPOT_HISTORY_KEY = 'metalSpotHistory';
+const SPOT_HISTORY_KEY = "metalSpotHistory";
 
 /** @constant {string} THEME_KEY - LocalStorage key for theme preference */
-const THEME_KEY = 'appTheme';
+const THEME_KEY = "appTheme";
 
 /** @constant {string} API_KEY_STORAGE_KEY - LocalStorage key for API provider information */
-const API_KEY_STORAGE_KEY = 'metalApiConfig';
+const API_KEY_STORAGE_KEY = "metalApiConfig";
 
 /** @constant {string} API_CACHE_KEY - LocalStorage key for cached API data */
-const API_CACHE_KEY = 'metalApiCache';
+const API_CACHE_KEY = "metalApiCache";
 
-/** @constant {number} API_CACHE_DURATION - Cache duration in milliseconds (24 hours) */
-const API_CACHE_DURATION = 24 * 60 * 60 * 1000;
+/**
+ * @constant {number} DEFAULT_API_CACHE_DURATION - Default cache duration in milliseconds (24 hours)
+ */
+const DEFAULT_API_CACHE_DURATION = 24 * 60 * 60 * 1000;
 
 /** @constant {boolean} DEV_MODE - Enables verbose debug logging when true */
 const DEV_MODE = false;
@@ -92,31 +125,31 @@ const DEV_MODE = false;
  */
 let DEBUG = DEV_MODE;
 
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   const params = new URLSearchParams(window.location.search);
-  if (params.has('debug')) {
-    const value = params.get('debug');
-    DEBUG = value === null || value === '' || value === '1' || value === 'true';
+  if (params.has("debug")) {
+    const value = params.get("debug");
+    DEBUG = value === null || value === "" || value === "1" || value === "true";
   }
 }
 
 /**
  * Metal configuration object - Central registry for all metal-related information
- * 
+ *
  * This configuration drives the entire application's metal handling by defining:
  * - Display names for user interface elements
  * - Key identifiers for data structures and calculations
  * - DOM element ID patterns for dynamic element selection
  * - LocalStorage keys for persistent data storage
  * - CSS color variables for styling and theming
- * 
+ *
  * Each metal configuration contains:
  * @property {string} name - Display name used in UI elements and forms
  * @property {string} key - Lowercase identifier for data objects and calculations
  * @property {string} spotKey - DOM ID pattern for spot price input elements
  * @property {string} localStorageKey - Key for storing spot prices in localStorage
  * @property {string} color - CSS custom property name for metal-specific styling
- * 
+ *
  * Adding a new metal type requires:
  * 1. Adding configuration here
  * 2. Adding corresponding HTML elements following the naming pattern
@@ -124,44 +157,44 @@ if (typeof window !== 'undefined') {
  * 4. The application will automatically handle the rest through iteration
  */
 const METALS = {
-  SILVER: { 
-    name: 'Silver', 
-    key: 'silver', 
-    spotKey: 'spotSilver',
-    localStorageKey: 'spotSilver',
-    color: 'silver',
-    defaultPrice: 25.00
+  SILVER: {
+    name: "Silver",
+    key: "silver",
+    spotKey: "spotSilver",
+    localStorageKey: "spotSilver",
+    color: "silver",
+    defaultPrice: 25.0,
   },
-  GOLD: { 
-    name: 'Gold', 
-    key: 'gold', 
-    spotKey: 'spotGold',
-    localStorageKey: 'spotGold',
-    color: 'gold',
-    defaultPrice: 2500.00
+  GOLD: {
+    name: "Gold",
+    key: "gold",
+    spotKey: "spotGold",
+    localStorageKey: "spotGold",
+    color: "gold",
+    defaultPrice: 2500.0,
   },
-  PLATINUM: { 
-    name: 'Platinum', 
-    key: 'platinum', 
-    spotKey: 'spotPlatinum',
-    localStorageKey: 'spotPlatinum',
-    color: 'platinum',
-    defaultPrice: 1000.00
+  PLATINUM: {
+    name: "Platinum",
+    key: "platinum",
+    spotKey: "spotPlatinum",
+    localStorageKey: "spotPlatinum",
+    color: "platinum",
+    defaultPrice: 1000.0,
   },
-  PALLADIUM: { 
-    name: 'Palladium', 
-    key: 'palladium', 
-    spotKey: 'spotPalladium',
-    localStorageKey: 'spotPalladium',
-    color: 'palladium',
-    defaultPrice: 1000.00
-  }
+  PALLADIUM: {
+    name: "Palladium",
+    key: "palladium",
+    spotKey: "spotPalladium",
+    localStorageKey: "spotPalladium",
+    color: "palladium",
+    defaultPrice: 1000.0,
+  },
 };
 
 // =============================================================================
 
 // Expose globals
-if (typeof window !== 'undefined') {
+if (typeof window !== "undefined") {
   window.API_PROVIDERS = API_PROVIDERS;
   window.METALS = METALS;
   window.DEBUG = DEBUG;

--- a/js/events.js
+++ b/js/events.js
@@ -1,6 +1,6 @@
 /**
  * EVENTS MODULE - FIXED VERSION
- * 
+ *
  * Handles all DOM event listeners with proper null checking and error handling.
  * Includes file protocol compatibility fixes and fallback event attachment methods.
  */
@@ -16,9 +16,11 @@
  * @param {string} description - Description for logging
  * @returns {boolean} Success status
  */
-const safeAttachListener = (element, event, handler, description = '') => {
+const safeAttachListener = (element, event, handler, description = "") => {
   if (!element) {
-    console.warn(`Cannot attach ${event} listener: element not found (${description})`);
+    console.warn(
+      `Cannot attach ${event} listener: element not found (${description})`,
+    );
     return false;
   }
 
@@ -28,14 +30,17 @@ const safeAttachListener = (element, event, handler, description = '') => {
     return true;
   } catch (error) {
     console.warn(`Standard addEventListener failed for ${description}:`, error);
-    
+
     try {
       // Method 2: Legacy event handler
-      element['on' + event] = handler;
+      element["on" + event] = handler;
       debugLog(`✓ Fallback event handler attached: ${description}`);
       return true;
     } catch (fallbackError) {
-      console.error(`All event attachment methods failed for ${description}:`, fallbackError);
+      console.error(
+        `All event attachment methods failed for ${description}:`,
+        fallbackError,
+      );
       return false;
     }
   }
@@ -45,15 +50,15 @@ const safeAttachListener = (element, event, handler, description = '') => {
  * Implements dynamic column resizing for the inventory table
  */
 const setupColumnResizing = () => {
-  const table = document.getElementById('inventoryTable');
+  const table = document.getElementById("inventoryTable");
   if (!table) {
-    console.warn('Inventory table not found for column resizing');
+    console.warn("Inventory table not found for column resizing");
     return;
   }
 
   // Clear any existing resize handles
-  const existingHandles = table.querySelectorAll('.resize-handle');
-  existingHandles.forEach(handle => handle.remove());
+  const existingHandles = table.querySelectorAll(".resize-handle");
+  existingHandles.forEach((handle) => handle.remove());
 
   let isResizing = false;
   let currentColumn = null;
@@ -61,61 +66,84 @@ const setupColumnResizing = () => {
   let startWidth = 0;
 
   // Add resize handles to table headers
-  const headers = table.querySelectorAll('th');
+  const headers = table.querySelectorAll("th");
   headers.forEach((header, index) => {
     // Skip the last column (delete button)
     if (index === headers.length - 1) return;
 
-    const resizeHandle = document.createElement('div');
-    resizeHandle.className = 'resize-handle';
+    const resizeHandle = document.createElement("div");
+    resizeHandle.className = "resize-handle";
 
-    header.style.position = 'relative';
+    header.style.position = "relative";
     header.appendChild(resizeHandle);
 
-    safeAttachListener(resizeHandle, 'mousedown', (e) => {
-      isResizing = true;
-      currentColumn = header;
-      startX = e.clientX;
-      startWidth = parseInt(document.defaultView.getComputedStyle(header).width, 10);
-      
-      e.preventDefault();
-      e.stopPropagation();
-      
-      // Prevent header click event from firing
-      header.style.pointerEvents = 'none';
-      setTimeout(() => {
-        header.style.pointerEvents = 'auto';
-      }, 100);
-    }, 'Column resize handle');
+    safeAttachListener(
+      resizeHandle,
+      "mousedown",
+      (e) => {
+        isResizing = true;
+        currentColumn = header;
+        startX = e.clientX;
+        startWidth = parseInt(
+          document.defaultView.getComputedStyle(header).width,
+          10,
+        );
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Prevent header click event from firing
+        header.style.pointerEvents = "none";
+        setTimeout(() => {
+          header.style.pointerEvents = "auto";
+        }, 100);
+      },
+      "Column resize handle",
+    );
   });
 
   // Handle mouse move for resizing
-  safeAttachListener(document, 'mousemove', (e) => {
-    if (!isResizing || !currentColumn) return;
+  safeAttachListener(
+    document,
+    "mousemove",
+    (e) => {
+      if (!isResizing || !currentColumn) return;
 
-    const width = startWidth + e.clientX - startX;
-    const minWidth = 40;
-    const maxWidth = 300;
-    
-    if (width >= minWidth && width <= maxWidth) {
-      currentColumn.style.width = width + 'px';
-    }
-  }, 'Document mousemove for resizing');
+      const width = startWidth + e.clientX - startX;
+      const minWidth = 40;
+      const maxWidth = 300;
+
+      if (width >= minWidth && width <= maxWidth) {
+        currentColumn.style.width = width + "px";
+      }
+    },
+    "Document mousemove for resizing",
+  );
 
   // Handle mouse up to stop resizing
-  safeAttachListener(document, 'mouseup', () => {
-    if (isResizing) {
-      isResizing = false;
-      currentColumn = null;
-    }
-  }, 'Document mouseup for resizing');
+  safeAttachListener(
+    document,
+    "mouseup",
+    () => {
+      if (isResizing) {
+        isResizing = false;
+        currentColumn = null;
+      }
+    },
+    "Document mouseup for resizing",
+  );
 
   // Prevent text selection during resize
-  safeAttachListener(document, 'selectstart', (e) => {
-    if (isResizing) {
-      e.preventDefault();
-    }
-  }, 'Document selectstart for resizing');
+  safeAttachListener(
+    document,
+    "selectstart",
+    (e) => {
+      if (isResizing) {
+        e.preventDefault();
+      }
+    },
+    "Document selectstart for resizing",
+  );
 };
 
 // MAIN EVENT LISTENERS SETUP
@@ -125,496 +153,660 @@ const setupColumnResizing = () => {
  * Sets up all primary event listeners for the application
  */
 const setupEventListeners = () => {
-
   console.log(`Setting up event listeners (v${APP_VERSION})...`);
 
   try {
     // CRITICAL HEADER BUTTONS
-    debugLog('Setting up header buttons...');
-    
-    // API Button
-    if (elements.apiBtn) {
-      safeAttachListener(elements.apiBtn, 'click', (e) => {
-        e.preventDefault();
-        debugLog('API button clicked');
-        if (typeof showApiModal === 'function') {
-          showApiModal();
-        } else {
-          alert('API Configuration Modal\n\nThis would open the API configuration interface where you can:\n\n• Configure API providers\n• Set API keys\n• Sync spot prices automatically\n• View API status and cache info');
-        }
-      }, 'API Button');
+    debugLog("Setting up header buttons...");
+
+    // Settings Button
+    if (elements.settingsBtn) {
+      safeAttachListener(
+        elements.settingsBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          debugLog("Settings button clicked");
+          if (typeof showSettingsModal === "function") {
+            showSettingsModal();
+          } else {
+            alert("Settings interface");
+          }
+        },
+        "Settings Button",
+      );
     } else {
-      console.error('API button element not found!');
+      console.error("Settings button element not found!");
     }
 
     // About Button
     if (elements.aboutBtn) {
-      safeAttachListener(elements.aboutBtn, 'click', (e) => {
-        e.preventDefault();
-        if (typeof showAboutModal === 'function') {
-          showAboutModal();
-        }
-      }, 'About Button');
+      safeAttachListener(
+        elements.aboutBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof showAboutModal === "function") {
+            showAboutModal();
+          }
+        },
+        "About Button",
+      );
     }
 
-    // Theme Toggle Button
-    if (elements.themeToggle) {
-      safeAttachListener(elements.themeToggle, 'click', (e) => {
-        e.preventDefault();
-        debugLog('Theme toggle clicked');
-        
-        if (typeof toggleTheme === 'function') {
-          toggleTheme();
-        } else if (typeof setTheme === 'function') {
-          // Fallback to manual toggle
-          const currentTheme = localStorage.getItem(THEME_KEY) || 'light';
-          const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-          setTheme(newTheme);
-        } else {
-          // Ultimate fallback
-          const currentTheme = document.documentElement.getAttribute('data-theme');
-          const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-          if (newTheme === 'dark') {
-            document.documentElement.setAttribute('data-theme', 'dark');
-            localStorage.setItem(THEME_KEY, 'dark');
-            elements.themeToggle.textContent = 'Light Mode';
-          } else {
-            document.documentElement.removeAttribute('data-theme');
-            localStorage.setItem(THEME_KEY, 'light');
-            elements.themeToggle.textContent = 'Dark Mode';
+    // Theme preference radios
+    const themeRadios = document.querySelectorAll(
+      'input[name="themePreference"]',
+    );
+    themeRadios.forEach((radio) => {
+      safeAttachListener(
+        radio,
+        "change",
+        () => {
+          const value = radio.value;
+          if (typeof setTheme === "function") {
+            setTheme(value);
           }
-        }
-      }, 'Theme Toggle');
-    } else {
-      console.error('Theme toggle button element not found!');
-    }
+        },
+        "Theme preference change",
+      );
+    });
 
     // Details modal buttons
     if (elements.detailsButtons && elements.detailsButtons.length) {
-      elements.detailsButtons.forEach(btn => {
-        safeAttachListener(btn, 'click', () => {
-          const metal = btn.dataset.metal;
-          if (typeof showDetailsModal === 'function') {
-            showDetailsModal(metal);
-          }
-        }, `Details button (${btn.dataset.metal})`);
+      elements.detailsButtons.forEach((btn) => {
+        safeAttachListener(
+          btn,
+          "click",
+          () => {
+            const metal = btn.dataset.metal;
+            if (typeof showDetailsModal === "function") {
+              showDetailsModal(metal);
+            }
+          },
+          `Details button (${btn.dataset.metal})`,
+        );
       });
     }
 
     if (elements.closeDetailsBtn) {
-      safeAttachListener(elements.closeDetailsBtn, 'click', () => {
-        if (typeof closeDetailsModal === 'function') {
-          closeDetailsModal();
-        }
-      }, 'Close details modal');
+      safeAttachListener(
+        elements.closeDetailsBtn,
+        "click",
+        () => {
+          if (typeof closeDetailsModal === "function") {
+            closeDetailsModal();
+          }
+        },
+        "Close details modal",
+      );
     }
 
     // TABLE HEADER SORTING
-    debugLog('Setting up table sorting...');
-    const inventoryTable = document.getElementById('inventoryTable');
+    debugLog("Setting up table sorting...");
+    const inventoryTable = document.getElementById("inventoryTable");
     if (inventoryTable) {
-      const headers = inventoryTable.querySelectorAll('th');
+      const headers = inventoryTable.querySelectorAll("th");
       headers.forEach((header, index) => {
         // Skip Notes/Delete columns (last two)
         if (index >= headers.length - 2) {
           return;
         }
 
-        header.style.cursor = 'pointer';
+        header.style.cursor = "pointer";
 
-        safeAttachListener(header, 'click', () => {
-          // Toggle sort direction if same column, otherwise set to new column with asc
-          if (sortColumn === index) {
-            sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
-          } else {
-            sortColumn = index;
-            sortDirection = 'asc';
-          }
+        safeAttachListener(
+          header,
+          "click",
+          () => {
+            // Toggle sort direction if same column, otherwise set to new column with asc
+            if (sortColumn === index) {
+              sortDirection = sortDirection === "asc" ? "desc" : "asc";
+            } else {
+              sortColumn = index;
+              sortDirection = "asc";
+            }
 
-          renderTable();
-        }, `Table header ${index}`);
+            renderTable();
+          },
+          `Table header ${index}`,
+        );
       });
     } else {
-      console.error('Inventory table not found for sorting setup!');
+      console.error("Inventory table not found for sorting setup!");
     }
 
     // MAIN FORM SUBMISSION
-    debugLog('Setting up main form...');
+    debugLog("Setting up main form...");
     if (elements.inventoryForm) {
-      safeAttachListener(elements.inventoryForm, 'submit', function(e) {
-        e.preventDefault();
+      safeAttachListener(
+        elements.inventoryForm,
+        "submit",
+        function (e) {
+          e.preventDefault();
 
-        const metal = elements.itemMetal.value;
-        const name = elements.itemName.value.trim();
-        const qty = parseInt(elements.itemQty.value, 10);
-        const type = elements.itemType.value;
-        const weight = parseFloat(elements.itemWeight.value);
-        const price = parseFloat(elements.itemPrice.value);
-        const purchaseLocation = elements.purchaseLocation.value.trim() || "Unknown";
-        const storageLocation = elements.storageLocation.value.trim() || "Unknown";
-        const notes = elements.itemNotes.value.trim() || "";
-        const date = elements.itemDate.value || todayStr();
+          const metal = elements.itemMetal.value;
+          const name = elements.itemName.value.trim();
+          const qty = parseInt(elements.itemQty.value, 10);
+          const type = elements.itemType.value;
+          const weight = parseFloat(elements.itemWeight.value);
+          const price = parseFloat(elements.itemPrice.value);
+          const purchaseLocation =
+            elements.purchaseLocation.value.trim() || "Unknown";
+          const storageLocation =
+            elements.storageLocation.value.trim() || "Unknown";
+          const notes = elements.itemNotes.value.trim() || "";
+          const date = elements.itemDate.value || todayStr();
 
-        if (isNaN(qty) || qty < 1 || !Number.isInteger(qty) ||
-            isNaN(weight) || weight <= 0 ||
-            isNaN(price) || price < 0) {
-          return alert("Please enter valid values for all fields.");
-        }
+          if (
+            isNaN(qty) ||
+            qty < 1 ||
+            !Number.isInteger(qty) ||
+            isNaN(weight) ||
+            weight <= 0 ||
+            isNaN(price) ||
+            price < 0
+          ) {
+            return alert("Please enter valid values for all fields.");
+          }
 
-        // Get current spot price
-        const metalKey = metal.toLowerCase();
-        const spotPriceAtPurchase = spotPrices[metalKey];
+          // Get current spot price
+          const metalKey = metal.toLowerCase();
+          const spotPriceAtPurchase = spotPrices[metalKey];
 
-        // Calculate premium per ounce (only for non-collectible items)
-        let premiumPerOz = 0;
-        let totalPremium = 0;
+          // Calculate premium per ounce (only for non-collectible items)
+          let premiumPerOz = 0;
+          let totalPremium = 0;
 
-        // For new items, they're not collectable by default
-        const isCollectable = false;
+          // For new items, they're not collectable by default
+          const isCollectable = false;
 
-        if (!isCollectable) {
-          const pricePerOz = price / weight;
-          premiumPerOz = pricePerOz - spotPriceAtPurchase;
-          totalPremium = premiumPerOz * qty * weight;
-        }
+          if (!isCollectable) {
+            const pricePerOz = price / weight;
+            premiumPerOz = pricePerOz - spotPriceAtPurchase;
+            totalPremium = premiumPerOz * qty * weight;
+          }
 
-        inventory.push({ 
-          metal, 
-          name, 
-          qty, 
-          type, 
-          weight, 
-          price, 
-          date,
-          purchaseLocation,
-          storageLocation,
-          notes,
-          spotPriceAtPurchase,
-          premiumPerOz,
-          totalPremium,
-          isCollectable
-        });
+          inventory.push({
+            metal,
+            name,
+            qty,
+            type,
+            weight,
+            price,
+            date,
+            purchaseLocation,
+            storageLocation,
+            notes,
+            spotPriceAtPurchase,
+            premiumPerOz,
+            totalPremium,
+            isCollectable,
+          });
 
-        saveInventory();
-        renderTable();
-        this.reset();
-        elements.itemDate.value = todayStr();
-      }, 'Main inventory form');
+          saveInventory();
+          renderTable();
+          this.reset();
+          elements.itemDate.value = todayStr();
+        },
+        "Main inventory form",
+      );
     } else {
-      console.error('Main inventory form not found!');
+      console.error("Main inventory form not found!");
     }
 
     // EDIT FORM SUBMISSION
-    debugLog('Setting up edit form...');
+    debugLog("Setting up edit form...");
     if (elements.editForm) {
-      safeAttachListener(elements.editForm, 'submit', function(e) {
-        e.preventDefault();
+      safeAttachListener(
+        elements.editForm,
+        "submit",
+        function (e) {
+          e.preventDefault();
 
-        if (editingIndex === null) return;
+          if (editingIndex === null) return;
 
-        const metal = elements.editMetal.value;
-        const name = elements.editName.value.trim();
-        const qty = parseInt(elements.editQty.value, 10);
-        const type = elements.editType.value;
-        const weight = parseFloat(elements.editWeight.value);
-        const price = parseFloat(elements.editPrice.value);
-        const purchaseLocation = elements.editPurchaseLocation.value.trim() || "Unknown";
-        const storageLocation = elements.editStorageLocation.value.trim() || "Unknown";
-        const notes = elements.editNotes.value.trim() || "";
-        const date = elements.editDate.value;
+          const metal = elements.editMetal.value;
+          const name = elements.editName.value.trim();
+          const qty = parseInt(elements.editQty.value, 10);
+          const type = elements.editType.value;
+          const weight = parseFloat(elements.editWeight.value);
+          const price = parseFloat(elements.editPrice.value);
+          const purchaseLocation =
+            elements.editPurchaseLocation.value.trim() || "Unknown";
+          const storageLocation =
+            elements.editStorageLocation.value.trim() || "Unknown";
+          const notes = elements.editNotes.value.trim() || "";
+          const date = elements.editDate.value;
 
-        // Use the checkbox state the user just set
-        const isCollectable = document.getElementById("editCollectable").checked;
+          // Use the checkbox state the user just set
+          const isCollectable =
+            document.getElementById("editCollectable").checked;
 
-        // Get spot price input value
-        const spotPriceInput = elements.editSpotPrice.value.trim();
+          // Get spot price input value
+          const spotPriceInput = elements.editSpotPrice.value.trim();
 
-        // If spot price is empty and item is not collectable, use current spot price
-        let spotPriceAtPurchase;
-        if (!isCollectable && spotPriceInput === '') {
-          const metalKey = metal.toLowerCase();
-          spotPriceAtPurchase = spotPrices[metalKey];
-        } else {
-          spotPriceAtPurchase = parseFloat(spotPriceInput);
-        }
+          // If spot price is empty and item is not collectable, use current spot price
+          let spotPriceAtPurchase;
+          if (!isCollectable && spotPriceInput === "") {
+            const metalKey = metal.toLowerCase();
+            spotPriceAtPurchase = spotPrices[metalKey];
+          } else {
+            spotPriceAtPurchase = parseFloat(spotPriceInput);
+          }
 
-        if (isNaN(qty) || qty < 1 || !Number.isInteger(qty) ||
-            isNaN(weight) || weight <= 0 ||
-            isNaN(price) || price < 0 ||
-            (!isCollectable && (isNaN(spotPriceAtPurchase) || spotPriceAtPurchase <= 0))) {
-          return alert("Please enter valid values for all fields.");
-        }
+          if (
+            isNaN(qty) ||
+            qty < 1 ||
+            !Number.isInteger(qty) ||
+            isNaN(weight) ||
+            weight <= 0 ||
+            isNaN(price) ||
+            price < 0 ||
+            (!isCollectable &&
+              (isNaN(spotPriceAtPurchase) || spotPriceAtPurchase <= 0))
+          ) {
+            return alert("Please enter valid values for all fields.");
+          }
 
-        // Calculate premium per ounce (only for non-collectible items)
-        let premiumPerOz = 0;
-        let totalPremium = 0;
+          // Calculate premium per ounce (only for non-collectible items)
+          let premiumPerOz = 0;
+          let totalPremium = 0;
 
-        if (!isCollectable) {
-          const pricePerOz = price / weight;
-          premiumPerOz = pricePerOz - spotPriceAtPurchase;
-          totalPremium = premiumPerOz * qty * weight;
-        }
+          if (!isCollectable) {
+            const pricePerOz = price / weight;
+            premiumPerOz = pricePerOz - spotPriceAtPurchase;
+            totalPremium = premiumPerOz * qty * weight;
+          }
 
-        // Update the item
-        inventory[editingIndex] = {
-          metal,
-          name,
-          qty,
-          type,
-          weight,
-          price,
-          date,
-          purchaseLocation,
-          storageLocation,
-          notes,
-          spotPriceAtPurchase: isCollectable ? 0 : spotPriceAtPurchase,
-          premiumPerOz,
-          totalPremium,
-          isCollectable
-        };
+          // Update the item
+          inventory[editingIndex] = {
+            metal,
+            name,
+            qty,
+            type,
+            weight,
+            price,
+            date,
+            purchaseLocation,
+            storageLocation,
+            notes,
+            spotPriceAtPurchase: isCollectable ? 0 : spotPriceAtPurchase,
+            premiumPerOz,
+            totalPremium,
+            isCollectable,
+          };
 
-        saveInventory();
-        renderTable();
+          saveInventory();
+          renderTable();
 
-        // Close modal
-        elements.editModal.style.display = 'none';
-        editingIndex = null;
-      }, 'Edit form');
+          // Close modal
+          elements.editModal.style.display = "none";
+          editingIndex = null;
+        },
+        "Edit form",
+      );
     }
 
     // CANCEL EDIT BUTTON
     if (elements.cancelEditBtn) {
-      safeAttachListener(elements.cancelEditBtn, 'click', function() {
-        elements.editModal.style.display = 'none';
-        editingIndex = null;
-      }, 'Cancel edit button');
+      safeAttachListener(
+        elements.cancelEditBtn,
+        "click",
+        function () {
+          elements.editModal.style.display = "none";
+          editingIndex = null;
+        },
+        "Cancel edit button",
+      );
     }
 
     // NOTES MODAL BUTTONS
     if (elements.saveNotesBtn) {
-      safeAttachListener(elements.saveNotesBtn, 'click', () => {
-        if (notesIndex === null) return;
-        const textareaElement = elements.notesTextarea || document.getElementById('notesTextarea');
-        const text = textareaElement ? textareaElement.value.trim() : "";
-        
-        inventory[notesIndex].notes = text;
-        saveInventory();
-        renderTable();
-        
-        const modalElement = elements.notesModal || document.getElementById('notesModal');
-        if (modalElement) {
-          modalElement.style.display = 'none';
-        }
-        notesIndex = null;
-      }, 'Save notes button');
+      safeAttachListener(
+        elements.saveNotesBtn,
+        "click",
+        () => {
+          if (notesIndex === null) return;
+          const textareaElement =
+            elements.notesTextarea || document.getElementById("notesTextarea");
+          const text = textareaElement ? textareaElement.value.trim() : "";
+
+          inventory[notesIndex].notes = text;
+          saveInventory();
+          renderTable();
+
+          const modalElement =
+            elements.notesModal || document.getElementById("notesModal");
+          if (modalElement) {
+            modalElement.style.display = "none";
+          }
+          notesIndex = null;
+        },
+        "Save notes button",
+      );
     }
 
     if (elements.cancelNotesBtn) {
-      safeAttachListener(elements.cancelNotesBtn, 'click', () => {
-        const modalElement = elements.notesModal || document.getElementById('notesModal');
-        if (modalElement) {
-          modalElement.style.display = 'none';
-        }
-        notesIndex = null;
-      }, 'Cancel notes button');
+      safeAttachListener(
+        elements.cancelNotesBtn,
+        "click",
+        () => {
+          const modalElement =
+            elements.notesModal || document.getElementById("notesModal");
+          if (modalElement) {
+            modalElement.style.display = "none";
+          }
+          notesIndex = null;
+        },
+        "Cancel notes button",
+      );
     }
 
     // SPOT PRICE EVENT LISTENERS
-    debugLog('Setting up spot price listeners...');
-    Object.values(METALS).forEach(metalConfig => {
+    debugLog("Setting up spot price listeners...");
+    Object.values(METALS).forEach((metalConfig) => {
       const metalKey = metalConfig.key;
       const metalName = metalConfig.name;
-      
+
       // Main spot price action buttons
       const addBtn = document.getElementById(`addBtn${metalName}`);
       const resetBtn = document.getElementById(`resetBtn${metalName}`);
       const syncBtn = document.getElementById(`syncBtn${metalName}`);
-      
+
       // Manual input buttons
       const saveBtn = elements.saveSpotBtn[metalKey];
       const cancelBtn = document.getElementById(`cancelSpotBtn${metalName}`);
       const inputEl = elements.userSpotPriceInput[metalKey];
-      
+
       // Add button - shows manual input
       if (addBtn) {
-        safeAttachListener(addBtn, 'click', () => {
-          debugLog(`Add button clicked for ${metalName}`);
-          const manualInput = document.getElementById(`manualInput${metalName}`);
-          if (manualInput) {
-            manualInput.style.display = 'block';
-            const input = document.getElementById(`userSpotPrice${metalName}`);
-            if (input) input.focus();
-          }
-        }, `Add spot price for ${metalName}`);
+        safeAttachListener(
+          addBtn,
+          "click",
+          () => {
+            debugLog(`Add button clicked for ${metalName}`);
+            const manualInput = document.getElementById(
+              `manualInput${metalName}`,
+            );
+            if (manualInput) {
+              manualInput.style.display = "block";
+              const input = document.getElementById(
+                `userSpotPrice${metalName}`,
+              );
+              if (input) input.focus();
+            }
+          },
+          `Add spot price for ${metalName}`,
+        );
       }
-      
+
       // Reset button
       if (resetBtn) {
-        safeAttachListener(resetBtn, 'click', () => {
-          debugLog(`Reset button clicked for ${metalName}`);
-          if (typeof resetSpotPrice === 'function') {
-            resetSpotPrice(metalName);
-          } else {
-            // Fallback reset functionality
-            const defaultPrice = metalConfig.defaultPrice;
-            localStorage.setItem(metalConfig.localStorageKey, defaultPrice.toString());
-            spotPrices[metalKey] = defaultPrice;
-            if (elements.spotPriceDisplay[metalKey]) {
-              elements.spotPriceDisplay[metalKey].textContent = formatDollar(defaultPrice);
+        safeAttachListener(
+          resetBtn,
+          "click",
+          () => {
+            debugLog(`Reset button clicked for ${metalName}`);
+            if (typeof resetSpotPrice === "function") {
+              resetSpotPrice(metalName);
+            } else {
+              // Fallback reset functionality
+              const defaultPrice = metalConfig.defaultPrice;
+              localStorage.setItem(
+                metalConfig.localStorageKey,
+                defaultPrice.toString(),
+              );
+              spotPrices[metalKey] = defaultPrice;
+              if (elements.spotPriceDisplay[metalKey]) {
+                elements.spotPriceDisplay[metalKey].textContent =
+                  formatDollar(defaultPrice);
+              }
+              updateSummary();
             }
-            updateSummary();
-          }
-        }, `Reset spot price for ${metalName}`);
+          },
+          `Reset spot price for ${metalName}`,
+        );
       }
-      
+
       // Sync button
       if (syncBtn) {
-        safeAttachListener(syncBtn, 'click', () => {
-          debugLog(`Sync button clicked for ${metalName}`);
-          if (typeof syncSpotPricesFromApi === 'function') {
-            syncSpotPricesFromApi(true);
-          } else {
-            alert('API sync functionality requires API configuration. Please configure an API provider first.');
-          }
-        }, `Sync spot price for ${metalName}`);
+        safeAttachListener(
+          syncBtn,
+          "click",
+          () => {
+            debugLog(`Sync button clicked for ${metalName}`);
+            if (typeof syncSpotPricesFromApi === "function") {
+              syncSpotPricesFromApi(true);
+            } else {
+              alert(
+                "API sync functionality requires API configuration. Please configure an API provider first.",
+              );
+            }
+          },
+          `Sync spot price for ${metalName}`,
+        );
       }
-      
+
       // Save button (in manual input)
       if (saveBtn) {
-        safeAttachListener(saveBtn, 'click', () => {
-          if (typeof updateManualSpot === 'function') {
-            updateManualSpot(metalKey);
-          } else {
-            console.error(`updateManualSpot function not available for ${metalName}`);
-          }
-        }, `Save manual spot price for ${metalName}`);
+        safeAttachListener(
+          saveBtn,
+          "click",
+          () => {
+            if (typeof updateManualSpot === "function") {
+              updateManualSpot(metalKey);
+            } else {
+              console.error(
+                `updateManualSpot function not available for ${metalName}`,
+              );
+            }
+          },
+          `Save manual spot price for ${metalName}`,
+        );
       }
-      
+
       // Cancel button (in manual input)
       if (cancelBtn) {
-        safeAttachListener(cancelBtn, 'click', () => {
-          const manualInput = document.getElementById(`manualInput${metalName}`);
-          if (manualInput) {
-            manualInput.style.display = 'none';
-            const input = document.getElementById(`userSpotPrice${metalName}`);
-            if (input) input.value = '';
-          }
-        }, `Cancel manual spot price for ${metalName}`);
+        safeAttachListener(
+          cancelBtn,
+          "click",
+          () => {
+            const manualInput = document.getElementById(
+              `manualInput${metalName}`,
+            );
+            if (manualInput) {
+              manualInput.style.display = "none";
+              const input = document.getElementById(
+                `userSpotPrice${metalName}`,
+              );
+              if (input) input.value = "";
+            }
+          },
+          `Cancel manual spot price for ${metalName}`,
+        );
       }
-      
+
       // Enter key in input field
       if (inputEl) {
-        safeAttachListener(inputEl, 'keydown', (e) => {
-          if (e.key === 'Enter' && typeof updateManualSpot === 'function') {
-            updateManualSpot(metalKey);
-          }
-        }, `Manual spot price input for ${metalName}`);
+        safeAttachListener(
+          inputEl,
+          "keydown",
+          (e) => {
+            if (e.key === "Enter" && typeof updateManualSpot === "function") {
+              updateManualSpot(metalKey);
+            }
+          },
+          `Manual spot price input for ${metalName}`,
+        );
       }
     });
 
     // IMPORT/EXPORT EVENT LISTENERS
-    debugLog('Setting up import/export listeners...');
-    
+    debugLog("Setting up import/export listeners...");
+
     if (elements.importCsvFile) {
-      safeAttachListener(elements.importCsvFile, 'change', function(e) {
-        if (e.target.files.length > 0) {
-          importCsv(e.target.files[0]);
-        }
-        this.value = '';
-      }, 'CSV import');
+      safeAttachListener(
+        elements.importCsvFile,
+        "change",
+        function (e) {
+          if (e.target.files.length > 0) {
+            importCsv(e.target.files[0]);
+          }
+          this.value = "";
+        },
+        "CSV import",
+      );
     }
 
     if (elements.importJsonFile) {
-      safeAttachListener(elements.importJsonFile, 'change', function(e) {
-        if (e.target.files.length > 0) {
-          importJson(e.target.files[0]);
-        }
-        this.value = '';
-      }, 'JSON import');
+      safeAttachListener(
+        elements.importJsonFile,
+        "change",
+        function (e) {
+          if (e.target.files.length > 0) {
+            importJson(e.target.files[0]);
+          }
+          this.value = "";
+        },
+        "JSON import",
+      );
     }
 
     if (elements.importExcelFile) {
-      safeAttachListener(elements.importExcelFile, 'change', function(e) {
-        if (e.target.files.length > 0) {
-          importExcel(e.target.files[0]);
-        }
-        this.value = '';
-      }, 'Excel import');
+      safeAttachListener(
+        elements.importExcelFile,
+        "change",
+        function (e) {
+          if (e.target.files.length > 0) {
+            importExcel(e.target.files[0]);
+          }
+          this.value = "";
+        },
+        "Excel import",
+      );
     }
 
     // Export buttons
     if (elements.exportCsvBtn) {
-      safeAttachListener(elements.exportCsvBtn, 'click', exportCsv, 'CSV export');
+      safeAttachListener(
+        elements.exportCsvBtn,
+        "click",
+        exportCsv,
+        "CSV export",
+      );
     }
     if (elements.exportJsonBtn) {
-      safeAttachListener(elements.exportJsonBtn, 'click', exportJson, 'JSON export');
+      safeAttachListener(
+        elements.exportJsonBtn,
+        "click",
+        exportJson,
+        "JSON export",
+      );
     }
     if (elements.exportExcelBtn) {
-      safeAttachListener(elements.exportExcelBtn, 'click', exportExcel, 'Excel export');
+      safeAttachListener(
+        elements.exportExcelBtn,
+        "click",
+        exportExcel,
+        "Excel export",
+      );
     }
     if (elements.exportPdfBtn) {
-      safeAttachListener(elements.exportPdfBtn, 'click', exportPdf, 'PDF export');
+      safeAttachListener(
+        elements.exportPdfBtn,
+        "click",
+        exportPdf,
+        "PDF export",
+      );
     }
     if (elements.exportHtmlBtn) {
-      safeAttachListener(elements.exportHtmlBtn, 'click', exportHtml, 'HTML export');
+      safeAttachListener(
+        elements.exportHtmlBtn,
+        "click",
+        exportHtml,
+        "HTML export",
+      );
     }
 
     // Backup All Button
     if (elements.backupAllBtn) {
-      safeAttachListener(elements.backupAllBtn, 'click', async () => {
-        if (typeof createBackupZip === 'function') {
-          await createBackupZip();
-        } else {
-          // Fallback: simple backup
-          alert('Creating backup using export functions...');
-          exportCsv();
-          exportJson();
-        }
-      }, 'Backup all button');
+      safeAttachListener(
+        elements.backupAllBtn,
+        "click",
+        async () => {
+          if (typeof createBackupZip === "function") {
+            await createBackupZip();
+          } else {
+            // Fallback: simple backup
+            alert("Creating backup using export functions...");
+            exportCsv();
+            exportJson();
+          }
+        },
+        "Backup all button",
+      );
     }
 
     // BOATING ACCIDENT BUTTON
     if (elements.boatingAccidentBtn) {
-      safeAttachListener(elements.boatingAccidentBtn, 'click', function() {
-        if (confirm("WARNING: This will erase ALL your data for this app (inventory, spot history, spot prices, API configuration).\n\nAre you sure you want to proceed?\n\nThis action cannot be undone!")) {
-          localStorage.removeItem(LS_KEY);
-          localStorage.removeItem(SPOT_HISTORY_KEY);
-          localStorage.removeItem(API_KEY_STORAGE_KEY);
-          localStorage.removeItem(API_CACHE_KEY);
-          Object.values(METALS).forEach(metalConfig => {
-            localStorage.removeItem(metalConfig.localStorageKey);
-          });
-          sessionStorage.clear();
+      safeAttachListener(
+        elements.boatingAccidentBtn,
+        "click",
+        function () {
+          if (
+            confirm(
+              "WARNING: This will erase ALL your data for this app (inventory, spot history, spot prices, API configuration).\n\nWould you like to download a backup before proceeding?",
+            )
+          ) {
+            if (typeof createBackupZip === "function") {
+              createBackupZip();
+            }
+          }
+          if (
+            confirm(
+              "Are you absolutely sure you want to clear all local data? This action cannot be undone!",
+            )
+          ) {
+            localStorage.removeItem(LS_KEY);
+            localStorage.removeItem(SPOT_HISTORY_KEY);
+            localStorage.removeItem(API_KEY_STORAGE_KEY);
+            localStorage.removeItem(API_CACHE_KEY);
+            Object.values(METALS).forEach((metalConfig) => {
+              localStorage.removeItem(metalConfig.localStorageKey);
+            });
+            sessionStorage.clear();
 
-          loadInventory();
-          renderTable();
-          loadSpotHistory();
-          fetchSpotPrice();
-          
-          // Clear API state
-          apiConfig = null;
-          apiCache = null;
-          updateSyncButtonStates();
-          
-          alert("All data has been erased.");
-        }
-      }, 'Boating accident button');
+            loadInventory();
+            renderTable();
+            loadSpotHistory();
+            fetchSpotPrice();
+
+            // Clear API state
+            apiConfig = { provider: "", keys: {} };
+            apiCache = null;
+            updateSyncButtonStates();
+
+            alert("All data has been erased.");
+          }
+        },
+        "Boating accident button",
+      );
     }
-    
+
     // API MODAL EVENT LISTENERS
-    debugLog('Setting up API modal listeners...');
+    debugLog("Setting up API modal listeners...");
     setupApiEvents();
-    
+
     // ABOUT MODAL EVENT LISTENERS
-    debugLog('Setting up about modal listeners...');
-    if (typeof setupAboutModalEvents === 'function') {
+    debugLog("Setting up about modal listeners...");
+    if (typeof setupAboutModalEvents === "function") {
       setupAboutModalEvents();
     }
 
-    debugLog('✓ All event listeners setup complete');
-    
+    debugLog("✓ All event listeners setup complete");
   } catch (error) {
-    console.error('❌ Error setting up event listeners:', error);
+    console.error("❌ Error setting up event listeners:", error);
     throw error; // Re-throw to trigger fallback in init.js
   }
 };
@@ -623,53 +815,78 @@ const setupEventListeners = () => {
  * Sets up pagination event listeners
  */
 const setupPagination = () => {
-  debugLog('Setting up pagination listeners...');
-  
+  debugLog("Setting up pagination listeners...");
+
   try {
     if (elements.itemsPerPage) {
-      safeAttachListener(elements.itemsPerPage, 'change', function() {
-        itemsPerPage = parseInt(this.value);
-        currentPage = 1;
-        renderTable();
-      }, 'Items per page select');
+      safeAttachListener(
+        elements.itemsPerPage,
+        "change",
+        function () {
+          itemsPerPage = parseInt(this.value);
+          currentPage = 1;
+          renderTable();
+        },
+        "Items per page select",
+      );
     }
 
     if (elements.prevPage) {
-      safeAttachListener(elements.prevPage, 'click', function() {
-        if (currentPage > 1) {
-          currentPage--;
-          renderTable();
-        }
-      }, 'Previous page button');
+      safeAttachListener(
+        elements.prevPage,
+        "click",
+        function () {
+          if (currentPage > 1) {
+            currentPage--;
+            renderTable();
+          }
+        },
+        "Previous page button",
+      );
     }
 
     if (elements.nextPage) {
-      safeAttachListener(elements.nextPage, 'click', function() {
-        const totalPages = calculateTotalPages(filterInventory());
-        if (currentPage < totalPages) {
-          currentPage++;
-          renderTable();
-        }
-      }, 'Next page button');
+      safeAttachListener(
+        elements.nextPage,
+        "click",
+        function () {
+          const totalPages = calculateTotalPages(filterInventory());
+          if (currentPage < totalPages) {
+            currentPage++;
+            renderTable();
+          }
+        },
+        "Next page button",
+      );
     }
 
     if (elements.firstPage) {
-      safeAttachListener(elements.firstPage, 'click', function() {
-        currentPage = 1;
-        renderTable();
-      }, 'First page button');
+      safeAttachListener(
+        elements.firstPage,
+        "click",
+        function () {
+          currentPage = 1;
+          renderTable();
+        },
+        "First page button",
+      );
     }
 
     if (elements.lastPage) {
-      safeAttachListener(elements.lastPage, 'click', function() {
-        currentPage = calculateTotalPages(filterInventory());
-        renderTable();
-      }, 'Last page button');
+      safeAttachListener(
+        elements.lastPage,
+        "click",
+        function () {
+          currentPage = calculateTotalPages(filterInventory());
+          renderTable();
+        },
+        "Last page button",
+      );
     }
-    
-    debugLog('✓ Pagination listeners setup complete');
+
+    debugLog("✓ Pagination listeners setup complete");
   } catch (error) {
-    console.error('❌ Error setting up pagination listeners:', error);
+    console.error("❌ Error setting up pagination listeners:", error);
   }
 };
 
@@ -677,32 +894,42 @@ const setupPagination = () => {
  * Sets up search event listeners
  */
 const setupSearch = () => {
-  debugLog('Setting up search listeners...');
-  
+  debugLog("Setting up search listeners...");
+
   try {
     if (elements.searchInput) {
-      safeAttachListener(elements.searchInput, 'input', function() {
-        searchQuery = this.value;
-        currentPage = 1; // Reset to first page when search changes
-        renderTable();
-      }, 'Search input');
+      safeAttachListener(
+        elements.searchInput,
+        "input",
+        function () {
+          searchQuery = this.value;
+          currentPage = 1; // Reset to first page when search changes
+          renderTable();
+        },
+        "Search input",
+      );
     }
 
     if (elements.clearSearchBtn) {
-      safeAttachListener(elements.clearSearchBtn, 'click', function() {
-        if (elements.searchInput) {
-          elements.searchInput.value = '';
-        }
-        searchQuery = '';
-        columnFilter = { field: null, value: null };
-        currentPage = 1;
-        renderTable();
-      }, 'Clear search button');
+      safeAttachListener(
+        elements.clearSearchBtn,
+        "click",
+        function () {
+          if (elements.searchInput) {
+            elements.searchInput.value = "";
+          }
+          searchQuery = "";
+          columnFilter = { field: null, value: null };
+          currentPage = 1;
+          renderTable();
+        },
+        "Clear search button",
+      );
     }
-    
-    debugLog('✓ Search listeners setup complete');
+
+    debugLog("✓ Search listeners setup complete");
   } catch (error) {
-    console.error('❌ Error setting up search listeners:', error);
+    console.error("❌ Error setting up search listeners:", error);
   }
 };
 
@@ -710,26 +937,26 @@ const setupSearch = () => {
  * Sets up theme toggle event listeners
  */
 const setupThemeToggle = () => {
-  debugLog('Setting up theme toggle...');
-  
+  debugLog("Setting up theme toggle...");
+
   try {
     // Initialize theme with system preference detection
-    if (typeof initTheme === 'function') {
+    if (typeof initTheme === "function") {
       initTheme();
     } else {
       // Fallback initialization
-      const savedTheme = localStorage.getItem(THEME_KEY) || 'light';
+      const savedTheme = localStorage.getItem(THEME_KEY) || "light";
       setTheme(savedTheme);
     }
-    
+
     // Set up system theme change listener
-    if (typeof setupSystemThemeListener === 'function') {
+    if (typeof setupSystemThemeListener === "function") {
       setupSystemThemeListener();
     }
-    
-    debugLog('✓ Theme toggle setup complete');
+
+    debugLog("✓ Theme toggle setup complete");
   } catch (error) {
-    console.error('❌ Error setting up theme toggle:', error);
+    console.error("❌ Error setting up theme toggle:", error);
   }
 };
 
@@ -737,23 +964,30 @@ const setupThemeToggle = () => {
  * Sets up event listeners for details buttons (called after totals are rendered)
  */
 const setupDetailsButtons = () => {
-  debugLog('Setting up details buttons...');
-  
+  debugLog("Setting up details buttons...");
+
   // Re-query details buttons since they're created dynamically
-  const detailsButtons = document.querySelectorAll('.details-btn');
-  
-  detailsButtons.forEach(btn => {
-    safeAttachListener(btn, 'click', () => {
-      const metal = btn.dataset.metal;
-      debugLog(`Details button clicked for ${metal}`);
-      if (typeof showDetailsModal === 'function') {
-        showDetailsModal(metal);
-      } else {
-        alert(`Details modal for ${metal} would show analytics charts and breakdowns`);
-      }
-    }, `Details button (${btn.dataset.metal})`);
+  const detailsButtons = document.querySelectorAll(".details-btn");
+
+  detailsButtons.forEach((btn) => {
+    safeAttachListener(
+      btn,
+      "click",
+      () => {
+        const metal = btn.dataset.metal;
+        debugLog(`Details button clicked for ${metal}`);
+        if (typeof showDetailsModal === "function") {
+          showDetailsModal(metal);
+        } else {
+          alert(
+            `Details modal for ${metal} would show analytics charts and breakdowns`,
+          );
+        }
+      },
+      `Details button (${btn.dataset.metal})`,
+    );
   });
-  
+
   debugLog(`✓ Setup ${detailsButtons.length} details button listeners`);
 };
 
@@ -761,114 +995,200 @@ const setupDetailsButtons = () => {
  * Sets up API-related event listeners
  */
 const setupApiEvents = () => {
-  debugLog('Setting up API events...');
-  
+  debugLog("Setting up API events...");
+
   try {
-    // API Modal Events
-    const apiModal = document.getElementById('apiModal');
-    const apiCancelBtn = document.getElementById('apiCancelBtn');
-    const apiClearBtn = document.getElementById('apiClearBtn');
-    const apiConfigForm = document.getElementById('apiConfigForm');
-    const apiProviderSelect = document.getElementById('apiProvider');
+    const settingsModal = document.getElementById("settingsModal");
+    const settingsCloseBtn = document.getElementById("settingsCloseBtn");
+    const infoModal = document.getElementById("apiInfoModal");
+    const infoCloseBtn = document.getElementById("apiInfoCloseBtn");
 
-    // Modal background click to close
-    if (apiModal) {
-      safeAttachListener(apiModal, 'click', (e) => {
-        if (e.target === apiModal && typeof hideApiModal === 'function') {
-          hideApiModal();
-        }
-      }, 'API modal background');
-    }
-
-    // Cancel button
-    if (apiCancelBtn) {
-      safeAttachListener(apiCancelBtn, 'click', () => {
-        if (typeof hideApiModal === 'function') {
-          hideApiModal();
-        }
-      }, 'API cancel button');
-    }
-
-    // Clear configuration button
-    if (apiClearBtn) {
-      safeAttachListener(apiClearBtn, 'click', () => {
-        if (confirm('This will remove your API configuration and cached data. Continue?')) {
-          if (typeof clearApiConfig === 'function') {
-            clearApiConfig();
+    if (settingsModal) {
+      safeAttachListener(
+        settingsModal,
+        "click",
+        (e) => {
+          if (
+            e.target === settingsModal &&
+            typeof hideSettingsModal === "function"
+          ) {
+            hideSettingsModal();
           }
-          if (typeof hideApiModal === 'function') {
-            hideApiModal();
-          }
-          alert('API configuration cleared.');
-        }
-      }, 'API clear button');
-    }
-    
-    // Sync now button
-    const apiSyncNowBtn = document.getElementById('apiSyncNowBtn');
-    if (apiSyncNowBtn) {
-      safeAttachListener(apiSyncNowBtn, 'click', async () => {
-        if (typeof syncSpotPricesFromApi === 'function') {
-          const success = await syncSpotPricesFromApi(true, true);
-          if (success && typeof updateApiStatus === 'function') {
-            updateApiStatus();
-          }
-        }
-      }, 'API sync now button');
-    }
-    
-    // Clear cache button
-    const apiClearCacheBtn = document.getElementById('apiClearCacheBtn');
-    if (apiClearCacheBtn) {
-      safeAttachListener(apiClearCacheBtn, 'click', () => {
-        if (typeof clearApiCache === 'function') {
-          clearApiCache();
-        }
-      }, 'API clear cache button');
+        },
+        "Settings modal background",
+      );
     }
 
-    // Form submission
-    if (apiConfigForm) {
-      safeAttachListener(apiConfigForm, 'submit', (e) => {
-        if (typeof handleApiConfigSubmit === 'function') {
-          handleApiConfigSubmit(e);
-        } else {
+    if (settingsCloseBtn) {
+      safeAttachListener(
+        settingsCloseBtn,
+        "click",
+        () => {
+          if (typeof hideSettingsModal === "function") {
+            hideSettingsModal();
+          }
+        },
+        "Settings close button",
+      );
+    }
+
+    if (infoModal) {
+      safeAttachListener(
+        infoModal,
+        "click",
+        (e) => {
+          if (
+            e.target === infoModal &&
+            typeof hideProviderInfo === "function"
+          ) {
+            hideProviderInfo();
+          }
+        },
+        "Provider info modal background",
+      );
+    }
+
+    if (infoCloseBtn) {
+      safeAttachListener(
+        infoCloseBtn,
+        "click",
+        () => {
+          if (typeof hideProviderInfo === "function") {
+            hideProviderInfo();
+          }
+        },
+        "Provider info close",
+      );
+    }
+
+    document.querySelectorAll(".api-info-link").forEach((link) => {
+      const provider = link.getAttribute("data-provider");
+      safeAttachListener(
+        link,
+        "click",
+        (e) => {
           e.preventDefault();
-          alert('API configuration handler not available');
-        }
-      }, 'API config form');
+          if (typeof showProviderInfo === "function") {
+            showProviderInfo(provider);
+          }
+        },
+        "API info link",
+      );
+    });
+
+    document.querySelectorAll(".api-sync-btn").forEach((btn) => {
+      const provider = btn.getAttribute("data-provider");
+      safeAttachListener(
+        btn,
+        "click",
+        () => {
+          if (typeof handleProviderSync === "function") {
+            handleProviderSync(provider);
+          }
+        },
+        "API sync button",
+      );
+    });
+
+    document.querySelectorAll(".api-clear-btn").forEach((btn) => {
+      const provider = btn.getAttribute("data-provider");
+      safeAttachListener(
+        btn,
+        "click",
+        () => {
+          if (typeof clearApiKey === "function") {
+            clearApiKey(provider);
+          }
+        },
+        "API clear key button",
+      );
+    });
+
+    const cacheDuration = document.getElementById("apiCacheDuration");
+    if (cacheDuration) {
+      safeAttachListener(
+        cacheDuration,
+        "change",
+        () => {
+          if (typeof setCacheDuration === "function") {
+            setCacheDuration(parseInt(cacheDuration.value, 10));
+          }
+        },
+        "API cache duration select",
+      );
     }
 
-    // Provider selection change
-    if (apiProviderSelect) {
-      safeAttachListener(apiProviderSelect, 'change', (e) => {
-        if (typeof updateProviderInfo === 'function') {
-          updateProviderInfo(e.target.value);
-        }
-      }, 'API provider select');
+    document
+      .querySelectorAll('input[name="defaultProvider"]')
+      .forEach((radio) => {
+        const provider = radio.value;
+        safeAttachListener(
+          radio,
+          "change",
+          () => {
+            if (radio.checked && typeof setDefaultProvider === "function") {
+              setDefaultProvider(provider);
+            }
+          },
+          "Default provider radio",
+        );
+      });
+
+    const clearCacheBtn = document.getElementById("clearApiCacheBtn");
+    if (clearCacheBtn) {
+      safeAttachListener(
+        clearCacheBtn,
+        "click",
+        () => {
+          if (typeof clearApiCache === "function") {
+            clearApiCache();
+          }
+        },
+        "Clear API cache button",
+      );
     }
 
     // ESC key to close modals
-    safeAttachListener(document, 'keydown', (e) => {
-      if (e.key === 'Escape') {
-        const apiModal = document.getElementById('apiModal');
-        const editModal = document.getElementById('editModal');
-        const detailsModal = document.getElementById('detailsModal');
-        
-        if (apiModal && apiModal.style.display === 'flex' && typeof hideApiModal === 'function') {
-          hideApiModal();
-        } else if (editModal && editModal.style.display === 'flex') {
-          editModal.style.display = 'none';
-          editingIndex = null;
-        } else if (detailsModal && detailsModal.style.display === 'flex' && typeof closeDetailsModal === 'function') {
-          closeDetailsModal();
-        }
-      }
-    }, 'ESC key modal close');
+    safeAttachListener(
+      document,
+      "keydown",
+      (e) => {
+        if (e.key === "Escape") {
+          const settingsModal = document.getElementById("settingsModal");
+          const infoModal = document.getElementById("apiInfoModal");
+          const editModal = document.getElementById("editModal");
+          const detailsModal = document.getElementById("detailsModal");
 
-    debugLog('✓ API events setup complete');
+          if (
+            settingsModal &&
+            settingsModal.style.display === "flex" &&
+            typeof hideSettingsModal === "function"
+          ) {
+            hideSettingsModal();
+          } else if (
+            infoModal &&
+            infoModal.style.display === "flex" &&
+            typeof hideProviderInfo === "function"
+          ) {
+            hideProviderInfo();
+          } else if (editModal && editModal.style.display === "flex") {
+            editModal.style.display = "none";
+            editingIndex = null;
+          } else if (
+            detailsModal &&
+            detailsModal.style.display === "flex" &&
+            typeof closeDetailsModal === "function"
+          ) {
+            closeDetailsModal();
+          }
+        }
+      },
+      "ESC key modal close",
+    );
+
+    debugLog("✓ API events setup complete");
   } catch (error) {
-    console.error('❌ Error setting up API events:', error);
+    console.error("❌ Error setting up API events:", error);
   }
 };
 

--- a/js/init.js
+++ b/js/init.js
@@ -7,16 +7,16 @@
  */
 function createDummyElement() {
   return {
-    textContent: '',
-    innerHTML: '',
+    textContent: "",
+    innerHTML: "",
     style: {},
-    value: '',
+    value: "",
     checked: false,
     disabled: false,
     addEventListener: () => {},
     removeEventListener: () => {},
     focus: () => {},
-    click: () => {}
+    click: () => {},
   };
 }
 
@@ -36,149 +36,162 @@ function safeGetElement(id, required = false) {
 
 /**
  * Main application initialization function - FIXED VERSION
- * 
+ *
  * This function coordinates the complete application startup process with proper
  * error handling and DOM element validation.
- * 
+ *
  * @returns {void} Fully initializes the application interface
  */
-document.addEventListener('DOMContentLoaded', () => {
-
+document.addEventListener("DOMContentLoaded", () => {
   console.log(`=== APPLICATION INITIALIZATION STARTED (v${APP_VERSION}) ===`);
 
   try {
     // Phase 1: Initialize Core DOM Elements
-    debugLog('Phase 1: Initializing core DOM elements...');
-    
+    debugLog("Phase 1: Initializing core DOM elements...");
+
     // Core form elements
-    elements.inventoryForm = safeGetElement('inventoryForm', true);
-    
-    const inventoryTableEl = safeGetElement('inventoryTable', true);
-    elements.inventoryTable = inventoryTableEl ? inventoryTableEl.querySelector('tbody') : null;
-    
-    elements.itemMetal = safeGetElement('itemMetal', true);
-    elements.itemName = safeGetElement('itemName', true);
-    elements.itemQty = safeGetElement('itemQty', true);
-    elements.itemType = safeGetElement('itemType', true);
-    elements.itemWeight = safeGetElement('itemWeight', true);
-    elements.itemPrice = safeGetElement('itemPrice', true);
-    elements.purchaseLocation = safeGetElement('purchaseLocation', true);
-    elements.storageLocation = safeGetElement('storageLocation');
-    elements.itemNotes = safeGetElement('itemNotes');
-    elements.itemDate = safeGetElement('itemDate', true);
+    elements.inventoryForm = safeGetElement("inventoryForm", true);
+
+    const inventoryTableEl = safeGetElement("inventoryTable", true);
+    elements.inventoryTable = inventoryTableEl
+      ? inventoryTableEl.querySelector("tbody")
+      : null;
+
+    elements.itemMetal = safeGetElement("itemMetal", true);
+    elements.itemName = safeGetElement("itemName", true);
+    elements.itemQty = safeGetElement("itemQty", true);
+    elements.itemType = safeGetElement("itemType", true);
+    elements.itemWeight = safeGetElement("itemWeight", true);
+    elements.itemPrice = safeGetElement("itemPrice", true);
+    elements.purchaseLocation = safeGetElement("purchaseLocation", true);
+    elements.storageLocation = safeGetElement("storageLocation");
+    elements.itemNotes = safeGetElement("itemNotes");
+    elements.itemDate = safeGetElement("itemDate", true);
 
     // Header buttons - CRITICAL
-    debugLog('Phase 2: Initializing header buttons...');
-    elements.apiBtn = safeGetElement('apiBtn', true);
-    elements.aboutBtn = safeGetElement('aboutBtn');
-    elements.themeToggle = safeGetElement('themeToggle', true);
-    
+    debugLog("Phase 2: Initializing header buttons...");
+    elements.settingsBtn = safeGetElement("settingsBtn", true);
+    elements.aboutBtn = safeGetElement("aboutBtn");
+
     // Check if critical buttons exist
-    debugLog('API Button found:', !!document.getElementById('apiBtn'));
-    debugLog('Theme Toggle found:', !!document.getElementById('themeToggle'));
+    debugLog(
+      "Settings Button found:",
+      !!document.getElementById("settingsBtn"),
+    );
 
     // Import/Export elements
-    debugLog('Phase 3: Initializing import/export elements...');
-    elements.importCsvFile = safeGetElement('importCsvFile');
-    elements.importJsonFile = safeGetElement('importJsonFile');
-    elements.importExcelFile = safeGetElement('importExcelFile');
-    elements.exportCsvBtn = safeGetElement('exportCsvBtn');
-    elements.exportJsonBtn = safeGetElement('exportJsonBtn');
-    elements.exportExcelBtn = safeGetElement('exportExcelBtn');
-    elements.exportPdfBtn = safeGetElement('exportPdfBtn');
-    elements.exportHtmlBtn = safeGetElement('exportHtmlBtn');
-    elements.backupAllBtn = safeGetElement('backupAllBtn');
-    elements.boatingAccidentBtn = safeGetElement('boatingAccidentBtn');
+    debugLog("Phase 3: Initializing import/export elements...");
+    elements.importCsvFile = safeGetElement("importCsvFile");
+    elements.importJsonFile = safeGetElement("importJsonFile");
+    elements.importExcelFile = safeGetElement("importExcelFile");
+    elements.importProgress = safeGetElement("importProgress");
+    elements.importProgressText = safeGetElement("importProgressText");
+    elements.exportCsvBtn = safeGetElement("exportCsvBtn");
+    elements.exportJsonBtn = safeGetElement("exportJsonBtn");
+    elements.exportExcelBtn = safeGetElement("exportExcelBtn");
+    elements.exportPdfBtn = safeGetElement("exportPdfBtn");
+    elements.exportHtmlBtn = safeGetElement("exportHtmlBtn");
+    elements.backupAllBtn = safeGetElement("backupAllBtn");
+    elements.boatingAccidentBtn = safeGetElement("boatingAccidentBtn");
 
     // Modal elements
-    debugLog('Phase 4: Initializing modal elements...');
-    elements.apiModal = safeGetElement('apiModal');
-    elements.aboutModal = safeGetElement('aboutModal');
-    elements.ackModal = safeGetElement('ackModal');
-    elements.ackAcceptBtn = safeGetElement('ackAcceptBtn');
-    elements.editModal = safeGetElement('editModal');
-    elements.editForm = safeGetElement('editForm');
-    elements.cancelEditBtn = safeGetElement('cancelEdit');
-    elements.editMetal = safeGetElement('editMetal');
-    elements.editName = safeGetElement('editName');
-    elements.editQty = safeGetElement('editQty');
-    elements.editType = safeGetElement('editType');
-    elements.editWeight = safeGetElement('editWeight');
-    elements.editPrice = safeGetElement('editPrice');
-    elements.editPurchaseLocation = safeGetElement('editPurchaseLocation');
-    elements.editStorageLocation = safeGetElement('editStorageLocation');
-    elements.editNotes = safeGetElement('editNotes');
-    elements.editDate = safeGetElement('editDate');
-    elements.editSpotPrice = safeGetElement('editSpotPrice');
+    debugLog("Phase 4: Initializing modal elements...");
+    elements.settingsModal = safeGetElement("settingsModal");
+    elements.apiInfoModal = safeGetElement("apiInfoModal");
+    elements.aboutModal = safeGetElement("aboutModal");
+    elements.ackModal = safeGetElement("ackModal");
+    elements.ackAcceptBtn = safeGetElement("ackAcceptBtn");
+    elements.editModal = safeGetElement("editModal");
+    elements.editForm = safeGetElement("editForm");
+    elements.cancelEditBtn = safeGetElement("cancelEdit");
+    elements.editMetal = safeGetElement("editMetal");
+    elements.editName = safeGetElement("editName");
+    elements.editQty = safeGetElement("editQty");
+    elements.editType = safeGetElement("editType");
+    elements.editWeight = safeGetElement("editWeight");
+    elements.editPrice = safeGetElement("editPrice");
+    elements.editPurchaseLocation = safeGetElement("editPurchaseLocation");
+    elements.editStorageLocation = safeGetElement("editStorageLocation");
+    elements.editNotes = safeGetElement("editNotes");
+    elements.editDate = safeGetElement("editDate");
+    elements.editSpotPrice = safeGetElement("editSpotPrice");
 
     // Show acknowledgment modal immediately and set up modal events
-    if (typeof setupAckModalEvents === 'function') {
+    if (typeof setupAckModalEvents === "function") {
       setupAckModalEvents();
     }
-    if (typeof showAckModal === 'function') {
+    if (typeof showAckModal === "function") {
       showAckModal();
     }
-    if (typeof setupAboutModalEvents === 'function') {
+    if (typeof setupAboutModalEvents === "function") {
       setupAboutModalEvents();
     }
 
     // Notes modal elements
-    elements.notesModal = safeGetElement('notesModal');
-    elements.notesTextarea = safeGetElement('notesTextarea');
-    elements.saveNotesBtn = safeGetElement('saveNotes');
-    elements.cancelNotesBtn = safeGetElement('cancelNotes');
-    
+    elements.notesModal = safeGetElement("notesModal");
+    elements.notesTextarea = safeGetElement("notesTextarea");
+    elements.saveNotesBtn = safeGetElement("saveNotes");
+    elements.cancelNotesBtn = safeGetElement("cancelNotes");
+
     // Pagination elements
-    debugLog('Phase 5: Initializing pagination elements...');
-    elements.itemsPerPage = safeGetElement('itemsPerPage');
-    elements.prevPage = safeGetElement('prevPage');
-    elements.nextPage = safeGetElement('nextPage');
-    elements.firstPage = safeGetElement('firstPage');
-    elements.lastPage = safeGetElement('lastPage');
-    elements.pageNumbers = safeGetElement('pageNumbers');
-    elements.paginationInfo = safeGetElement('paginationInfo');
-    
+    debugLog("Phase 5: Initializing pagination elements...");
+    elements.itemsPerPage = safeGetElement("itemsPerPage");
+    elements.prevPage = safeGetElement("prevPage");
+    elements.nextPage = safeGetElement("nextPage");
+    elements.firstPage = safeGetElement("firstPage");
+    elements.lastPage = safeGetElement("lastPage");
+    elements.pageNumbers = safeGetElement("pageNumbers");
+    elements.paginationInfo = safeGetElement("paginationInfo");
+
     // Search elements
-    debugLog('Phase 6: Initializing search elements...');
-    elements.searchInput = safeGetElement('searchInput');
-    elements.clearSearchBtn = safeGetElement('clearSearchBtn');
-    elements.searchResultsInfo = safeGetElement('searchResultsInfo');
+    debugLog("Phase 6: Initializing search elements...");
+    elements.searchInput = safeGetElement("searchInput");
+    elements.clearSearchBtn = safeGetElement("clearSearchBtn");
+    elements.searchResultsInfo = safeGetElement("searchResultsInfo");
 
     // Details modal elements
-    debugLog('Phase 7: Initializing details modal elements...');
-    elements.detailsModal = safeGetElement('detailsModal');
-    elements.detailsModalTitle = safeGetElement('detailsModalTitle');
-    elements.typeBreakdown = safeGetElement('typeBreakdown');
-    elements.locationBreakdown = safeGetElement('locationBreakdown');
-    elements.closeDetailsBtn = safeGetElement('closeDetailsBtn');
-    elements.detailsButtons = document.querySelectorAll('.details-btn');
+    debugLog("Phase 7: Initializing details modal elements...");
+    elements.detailsModal = safeGetElement("detailsModal");
+    elements.detailsModalTitle = safeGetElement("detailsModalTitle");
+    elements.typeBreakdown = safeGetElement("typeBreakdown");
+    elements.locationBreakdown = safeGetElement("locationBreakdown");
+    elements.closeDetailsBtn = safeGetElement("closeDetailsBtn");
+    elements.detailsButtons = document.querySelectorAll(".details-btn");
 
     // Chart elements
-    debugLog('Phase 8: Initializing chart elements...');
-    elements.typeChart = safeGetElement('typeChart');
-    elements.locationChart = safeGetElement('locationChart');
+    debugLog("Phase 8: Initializing chart elements...");
+    elements.typeChart = safeGetElement("typeChart");
+    elements.locationChart = safeGetElement("locationChart");
 
     // Phase 9: Initialize Metal-Specific Elements
-    debugLog('Phase 9: Initializing metal-specific elements...');
-    
+    debugLog("Phase 9: Initializing metal-specific elements...");
+
     // Initialize nested objects
     elements.spotPriceDisplay = {};
     elements.userSpotPriceInput = {};
     elements.saveSpotBtn = {};
     elements.resetSpotBtn = {};
-    
-    Object.values(METALS).forEach(metalConfig => {
+
+    Object.values(METALS).forEach((metalConfig) => {
       const metalKey = metalConfig.key;
       const metalName = metalConfig.name;
-      
+
       debugLog(`  Setting up ${metalName} elements...`);
-      
+
       // Spot price display elements with CORRECT IDs
-      elements.spotPriceDisplay[metalKey] = safeGetElement(`spotPriceDisplay${metalName}`);
-      elements.userSpotPriceInput[metalKey] = safeGetElement(`userSpotPrice${metalName}`);
-      elements.saveSpotBtn[metalKey] = safeGetElement(`saveSpotBtn${metalName}`);
-      elements.resetSpotBtn[metalKey] = safeGetElement(`resetSpotBtn${metalName}`);
-      
+      elements.spotPriceDisplay[metalKey] = safeGetElement(
+        `spotPriceDisplay${metalName}`,
+      );
+      elements.userSpotPriceInput[metalKey] = safeGetElement(
+        `userSpotPrice${metalName}`,
+      );
+      elements.saveSpotBtn[metalKey] = safeGetElement(
+        `saveSpotBtn${metalName}`,
+      );
+      elements.resetSpotBtn[metalKey] = safeGetElement(
+        `resetSpotBtn${metalName}`,
+      );
+
       // Debug log for each metal
       const displayEl = document.getElementById(`spotPriceDisplay${metalName}`);
       const inputEl = document.getElementById(`userSpotPrice${metalName}`);
@@ -187,16 +200,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Phase 10: Initialize Totals Elements
-    debugLog('Phase 10: Initializing totals elements...');
-    
+    debugLog("Phase 10: Initializing totals elements...");
+
     if (!elements.totals) {
       elements.totals = {};
     }
-    
-    Object.values(METALS).forEach(metalConfig => {
+
+    Object.values(METALS).forEach((metalConfig) => {
       const metalKey = metalConfig.key;
       const metalName = metalConfig.name;
-      
+
       elements.totals[metalKey] = {
         items: safeGetElement(`totalItems${metalName}`),
         weight: safeGetElement(`totalWeight${metalName}`),
@@ -207,64 +220,66 @@ document.addEventListener('DOMContentLoaded', () => {
         avgPrice: safeGetElement(`avgPrice${metalName}`),
         avgPremium: safeGetElement(`avgPremium${metalName}`),
         avgCollectablePrice: safeGetElement(`avgCollectablePrice${metalName}`),
-        avgNonCollectablePrice: safeGetElement(`avgNonCollectablePrice${metalName}`)
+        avgNonCollectablePrice: safeGetElement(
+          `avgNonCollectablePrice${metalName}`,
+        ),
       };
     });
 
     // Initialize "All" totals
     elements.totals.all = {
-      items: safeGetElement('totalItemsAll'),
-      weight: safeGetElement('totalWeightAll'),
-      value: safeGetElement('currentValueAll'),
-      purchased: safeGetElement('totalPurchasedAll'),
-      premium: safeGetElement('totalPremiumAll'),
-      lossProfit: safeGetElement('lossProfitAll'),
-      avgPrice: safeGetElement('avgPriceAll'),
-      avgPremium: safeGetElement('avgPremiumAll'),
-      avgCollectablePrice: safeGetElement('avgCollectablePriceAll'),
-      avgNonCollectablePrice: safeGetElement('avgNonCollectablePriceAll')
+      items: safeGetElement("totalItemsAll"),
+      weight: safeGetElement("totalWeightAll"),
+      value: safeGetElement("currentValueAll"),
+      purchased: safeGetElement("totalPurchasedAll"),
+      premium: safeGetElement("totalPremiumAll"),
+      lossProfit: safeGetElement("lossProfitAll"),
+      avgPrice: safeGetElement("avgPriceAll"),
+      avgPremium: safeGetElement("avgPremiumAll"),
+      avgCollectablePrice: safeGetElement("avgCollectablePriceAll"),
+      avgNonCollectablePrice: safeGetElement("avgNonCollectablePriceAll"),
     };
 
     // Phase 11: Version Management
-    debugLog('Phase 11: Updating version information...');
+    debugLog("Phase 11: Updating version information...");
     document.title = getAppTitle();
-    const appHeader = document.querySelector('.app-header h1');
+    const appHeader = document.querySelector(".app-header h1");
     if (appHeader) {
       appHeader.textContent = getAppTitle();
     }
-    const aboutVersion = document.getElementById('aboutVersion');
+    const aboutVersion = document.getElementById("aboutVersion");
     if (aboutVersion) {
       aboutVersion.textContent = `v${APP_VERSION}`;
     }
-    if (typeof loadChangelog === 'function') {
+    if (typeof loadChangelog === "function") {
       loadChangelog();
     }
 
     // Phase 12: Data Initialization
-    debugLog('Phase 12: Loading application data...');
-    
+    debugLog("Phase 12: Loading application data...");
+
     // Set default date
     if (elements.itemDate && elements.itemDate.value !== undefined) {
       elements.itemDate.value = todayStr();
     }
-    
+
     // Load data
     loadInventory();
     loadSpotHistory();
-    
+
     // Initialize API system
     apiConfig = loadApiConfig();
     apiCache = loadApiCache();
 
     // Phase 13: Initial Rendering
-    debugLog('Phase 13: Rendering initial display...');
+    debugLog("Phase 13: Rendering initial display...");
     renderTable();
     fetchSpotPrice();
     updateSyncButtonStates();
 
     // Phase 14: Event Listeners Setup (Delayed)
-    debugLog('Phase 14: Setting up event listeners...');
-    
+    debugLog("Phase 14: Setting up event listeners...");
+
     // Use a small delay to ensure all DOM manipulation is complete
     setTimeout(() => {
       try {
@@ -273,34 +288,34 @@ document.addEventListener('DOMContentLoaded', () => {
         setupSearch();
         setupThemeToggle();
         setupColumnResizing();
-        debugLog('✓ All event listeners setup complete');
+        debugLog("✓ All event listeners setup complete");
       } catch (eventError) {
-        console.error('❌ Error setting up event listeners:', eventError);
-        
+        console.error("❌ Error setting up event listeners:", eventError);
+
         // Try basic event setup as fallback
         setupBasicEventListeners();
       }
     }, 200); // Increased delay for better compatibility
-    
+
     // Phase 15: Completion
-    debugLog('=== INITIALIZATION COMPLETE ===');
-    debugLog('✓ Version:', APP_VERSION);
-    debugLog('✓ API configured:', !!apiConfig);
-    debugLog('✓ Inventory items:', inventory.length);
-    debugLog('✓ Critical elements check:');
-    debugLog('  - API button:', !!elements.apiBtn);
-    debugLog('  - Theme toggle:', !!elements.themeToggle);
-    debugLog('  - Inventory form:', !!elements.inventoryForm);
-    debugLog('  - Inventory table:', !!elements.inventoryTable);
-    
+    debugLog("=== INITIALIZATION COMPLETE ===");
+    debugLog("✓ Version:", APP_VERSION);
+    debugLog("✓ API configured:", !!apiConfig);
+    debugLog("✓ Inventory items:", inventory.length);
+    debugLog("✓ Critical elements check:");
+    debugLog("  - Settings button:", !!elements.settingsBtn);
+    debugLog("  - Inventory form:", !!elements.inventoryForm);
+    debugLog("  - Inventory table:", !!elements.inventoryTable);
   } catch (error) {
-    console.error('=== CRITICAL INITIALIZATION ERROR ===');
-    console.error('Error:', error.message);
-    console.error('Stack:', error.stack);
-    
+    console.error("=== CRITICAL INITIALIZATION ERROR ===");
+    console.error("Error:", error.message);
+    console.error("Stack:", error.stack);
+
     // Try to show a user-friendly error message
     setTimeout(() => {
-      alert(`Application initialization failed: ${error.message}\n\nPlease refresh the page and try again. If the problem persists, check the browser console for more details.`);
+      alert(
+        `Application initialization failed: ${error.message}\n\nPlease refresh the page and try again. If the problem persists, check the browser console for more details.`,
+      );
     }, 100);
   }
 });
@@ -309,40 +324,21 @@ document.addEventListener('DOMContentLoaded', () => {
  * Basic event listener setup as fallback
  */
 function setupBasicEventListeners() {
-  debugLog('Setting up basic event listeners as fallback...');
-  
-  // Theme toggle
-  const themeBtn = document.getElementById('themeToggle');
-  if (themeBtn) {
-    themeBtn.onclick = function() {
-      const currentTheme = localStorage.getItem(THEME_KEY) || 'light';
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      
-      if (newTheme === 'dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        localStorage.setItem(THEME_KEY, 'dark');
-        this.textContent = 'Light Mode';
+  debugLog("Setting up basic event listeners as fallback...");
+
+  // Settings button
+  const settingsBtn = document.getElementById("settingsBtn");
+  if (settingsBtn) {
+    settingsBtn.onclick = function () {
+      if (typeof showSettingsModal === "function") {
+        showSettingsModal();
       } else {
-        document.documentElement.removeAttribute('data-theme');
-        localStorage.setItem(THEME_KEY, 'light');
-        this.textContent = 'Dark Mode';
+        alert("Settings interface");
       }
     };
   }
-  
-  // API button
-  const apiBtn = document.getElementById('apiBtn');
-  if (apiBtn) {
-    apiBtn.onclick = function() {
-      if (typeof showApiModal === 'function') {
-        showApiModal();
-      } else {
-        alert('API configuration interface');
-      }
-    };
-  }
-  
-  debugLog('Basic event listeners setup complete');
+
+  debugLog("Basic event listeners setup complete");
 }
 
 // Make functions available globally for inline event handlers

--- a/js/spot.js
+++ b/js/spot.js
@@ -9,22 +9,28 @@ const saveSpotHistory = () => saveData(SPOT_HISTORY_KEY, spotHistory);
 /**
  * Loads spot history from localStorage
  */
-const loadSpotHistory = () => spotHistory = loadData(SPOT_HISTORY_KEY, []);
+const loadSpotHistory = () => (spotHistory = loadData(SPOT_HISTORY_KEY, []));
 
 /**
  * Records a new spot price entry in history
- * 
+ *
  * @param {number} newSpot - New spot price value
- * @param {string} source - Source of spot price ('manual' or other)
+ * @param {string} source - Source of spot price ('manual', 'api', etc.)
  * @param {string} metal - Metal type ('Silver', 'Gold', 'Platinum', or 'Palladium')
+ * @param {string|null} provider - Provider name if source is API-based
  */
-const recordSpot = (newSpot, source, metal) => {
-  if (!spotHistory.length || spotHistory[spotHistory.length-1].spot !== newSpot || spotHistory[spotHistory.length-1].metal !== metal) {
+const recordSpot = (newSpot, source, metal, provider = null) => {
+  if (
+    !spotHistory.length ||
+    spotHistory[spotHistory.length - 1].spot !== newSpot ||
+    spotHistory[spotHistory.length - 1].metal !== metal
+  ) {
     spotHistory.push({
       spot: newSpot,
       metal,
       source,
-      timestamp: new Date().toISOString().replace('T',' ').slice(0,19)
+      provider,
+      timestamp: new Date().toISOString().replace("T", " ").slice(0, 19),
     });
     saveSpotHistory();
   }
@@ -35,29 +41,41 @@ const recordSpot = (newSpot, source, metal) => {
  */
 const fetchSpotPrice = () => {
   // Load spot prices for all metals
-  Object.values(METALS).forEach(metalConfig => {
+  Object.values(METALS).forEach((metalConfig) => {
     const storedSpot = localStorage.getItem(metalConfig.localStorageKey);
     if (storedSpot) {
       spotPrices[metalConfig.key] = parseFloat(storedSpot);
-      if (elements.spotPriceDisplay[metalConfig.key] && elements.spotPriceDisplay[metalConfig.key].textContent !== undefined) {
-        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(spotPrices[metalConfig.key]);
+      if (
+        elements.spotPriceDisplay[metalConfig.key] &&
+        elements.spotPriceDisplay[metalConfig.key].textContent !== undefined
+      ) {
+        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(
+          spotPrices[metalConfig.key],
+        );
       }
-      recordSpot(spotPrices[metalConfig.key], 'stored', metalConfig.name);
+      recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
     } else {
       // Use default price if no stored price
       const defaultPrice = metalConfig.defaultPrice;
       spotPrices[metalConfig.key] = defaultPrice;
-      if (elements.spotPriceDisplay[metalConfig.key] && elements.spotPriceDisplay[metalConfig.key].textContent !== undefined) {
-        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(spotPrices[metalConfig.key]);
+      if (
+        elements.spotPriceDisplay[metalConfig.key] &&
+        elements.spotPriceDisplay[metalConfig.key].textContent !== undefined
+      ) {
+        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(
+          spotPrices[metalConfig.key],
+        );
       }
       // Don't record default prices in history automatically
     }
-    
+
     // Update timestamp display
-    const timestampElement = document.getElementById(`spotTimestamp${metalConfig.name}`);
+    const timestampElement = document.getElementById(
+      `spotTimestamp${metalConfig.name}`,
+    );
     if (timestampElement) {
       const lastUpdate = getLastUpdateTime(metalConfig.name);
-      timestampElement.textContent = lastUpdate || 'No data';
+      timestampElement.textContent = lastUpdate || "No data";
     }
   });
 
@@ -66,11 +84,11 @@ const fetchSpotPrice = () => {
 
 /**
  * Updates spot price for specified metal from user input
- * 
+ *
  * @param {string} metalKey - Key of metal to update ('silver', 'gold', 'platinum', 'palladium')
  */
 const updateManualSpot = (metalKey) => {
-  const metalConfig = Object.values(METALS).find(m => m.key === metalKey);
+  const metalConfig = Object.values(METALS).find((m) => m.key === metalKey);
   if (!metalConfig) return;
 
   const input = elements.userSpotPriceInput[metalKey];
@@ -79,72 +97,96 @@ const updateManualSpot = (metalKey) => {
   if (!value) return;
 
   const num = parseFloat(value);
-  if (isNaN(num) || num <= 0) return alert(`Invalid ${metalConfig.name.toLowerCase()} spot price.`);
+  if (isNaN(num) || num <= 0)
+    return alert(`Invalid ${metalConfig.name.toLowerCase()} spot price.`);
 
   localStorage.setItem(metalConfig.localStorageKey, num);
   spotPrices[metalKey] = num;
 
-  if (elements.spotPriceDisplay[metalKey] && elements.spotPriceDisplay[metalKey].textContent !== undefined) {
-    elements.spotPriceDisplay[metalKey].textContent = formatDollar(spotPrices[metalKey]);
+  if (
+    elements.spotPriceDisplay[metalKey] &&
+    elements.spotPriceDisplay[metalKey].textContent !== undefined
+  ) {
+    elements.spotPriceDisplay[metalKey].textContent = formatDollar(
+      spotPrices[metalKey],
+    );
   }
-  recordSpot(num, 'manual', metalConfig.name);
-  
+  recordSpot(num, "manual", metalConfig.name);
+
   // Update timestamp display
-  const timestampElement = document.getElementById(`spotTimestamp${metalConfig.name}`);
+  const timestampElement = document.getElementById(
+    `spotTimestamp${metalConfig.name}`,
+  );
   if (timestampElement) {
-    timestampElement.textContent = getLastUpdateTime(metalConfig.name) || 'No data';
+    timestampElement.textContent =
+      getLastUpdateTime(metalConfig.name) || "No data";
   }
 
   updateSummary();
-  
+
   // Clear the input and hide the manual input section if available
-  input.value = '';
-  if (typeof hideManualInput === 'function') {
+  input.value = "";
+  if (typeof hideManualInput === "function") {
     hideManualInput(metalConfig.name);
   }
 };
 
 /**
  * Resets spot price for specified metal to default or API cached value
- * 
+ *
  * @param {string} metalKey - Key of metal to reset ('silver', 'gold', 'platinum', 'palladium')
  */
 const resetSpot = (metalKey) => {
-  const metalConfig = Object.values(METALS).find(m => m.key === metalKey);
+  const metalConfig = Object.values(METALS).find((m) => m.key === metalKey);
   if (!metalConfig) return;
 
   let resetPrice = metalConfig.defaultPrice;
-  let source = 'default';
+  let source = "default";
+  let providerName = null;
 
   // If we have cached API data, use that instead
-  if (typeof apiCache !== 'undefined' && apiCache && apiCache.data && apiCache.data[metalKey]) {
+  if (
+    typeof apiCache !== "undefined" &&
+    apiCache &&
+    apiCache.data &&
+    apiCache.data[metalKey]
+  ) {
     resetPrice = apiCache.data[metalKey];
-    source = 'api';
+    source = "api";
+    providerName = API_PROVIDERS[apiCache.provider]?.name || null;
   }
 
   // Update price
   localStorage.setItem(metalConfig.localStorageKey, resetPrice.toString());
   spotPrices[metalKey] = resetPrice;
-  
+
   // Update display
-  if (elements.spotPriceDisplay[metalKey] && elements.spotPriceDisplay[metalKey].textContent !== undefined) {
-    elements.spotPriceDisplay[metalKey].textContent = formatDollar(spotPrices[metalKey]);
+  if (
+    elements.spotPriceDisplay[metalKey] &&
+    elements.spotPriceDisplay[metalKey].textContent !== undefined
+  ) {
+    elements.spotPriceDisplay[metalKey].textContent = formatDollar(
+      spotPrices[metalKey],
+    );
   }
-  
+
   // Record in history
-  recordSpot(resetPrice, source, metalConfig.name);
-  
+  recordSpot(resetPrice, source, metalConfig.name, providerName);
+
   // Update timestamp display
-  const timestampElement = document.getElementById(`spotTimestamp${metalConfig.name}`);
+  const timestampElement = document.getElementById(
+    `spotTimestamp${metalConfig.name}`,
+  );
   if (timestampElement) {
-    timestampElement.textContent = getLastUpdateTime(metalConfig.name) || 'No data';
+    timestampElement.textContent =
+      getLastUpdateTime(metalConfig.name) || "No data";
   }
-  
+
   // Update summary
   updateSummary();
-  
+
   // Hide manual input if shown and function is available
-  if (typeof hideManualInput === 'function') {
+  if (typeof hideManualInput === "function") {
     hideManualInput(metalConfig.name);
   }
 };
@@ -152,11 +194,11 @@ const resetSpot = (metalKey) => {
 /**
  * Alternative reset function that works with metal name instead of key
  * This provides compatibility with the API.js resetSpotPrice function
- * 
+ *
  * @param {string} metalName - Name of metal to reset ('Silver', 'Gold', etc.)
  */
 const resetSpotByName = (metalName) => {
-  const metalConfig = Object.values(METALS).find(m => m.name === metalName);
+  const metalConfig = Object.values(METALS).find((m) => m.name === metalName);
   if (metalConfig) {
     resetSpot(metalConfig.key);
   }

--- a/js/state.js
+++ b/js/state.js
@@ -2,8 +2,8 @@
 // =============================================================================
 
 /** @type {Object} Sorting state tracking */
-let sortColumn = null;        // Currently sorted column index (null = unsorted)
-let sortDirection = 'asc';    // 'asc' or 'desc' - current sort direction
+let sortColumn = null; // Currently sorted column index (null = unsorted)
+let sortDirection = "asc"; // 'asc' or 'desc' - current sort direction
 
 /** @type {number|null} Index of item being edited (null = no edit in progress) */
 let editingIndex = null;
@@ -11,11 +11,11 @@ let editingIndex = null;
 let notesIndex = null;
 
 /** @type {Object} Pagination state */
-let currentPage = 1;          // Current page number (1-based)
-let itemsPerPage = 25;        // Number of items to display per page
+let currentPage = 1; // Current page number (1-based)
+let itemsPerPage = 25; // Number of items to display per page
 
 /** @type {string} Current search query */
-let searchQuery = '';
+let searchQuery = "";
 
 /** @type {{field: string|null, value: string|null}} Active column filter */
 let columnFilter = { field: null, value: null };
@@ -23,7 +23,7 @@ let columnFilter = { field: null, value: null };
 /** @type {Object} Chart instances for proper cleanup */
 let chartInstances = {
   typeChart: null,
-  locationChart: null
+  locationChart: null,
 };
 
 /** @type {Object} Cached DOM elements for performance */
@@ -54,12 +54,12 @@ const elements = {
   resetSpotBtnSilver: null,
   resetSpotBtnGold: null,
 
-
-
   // Import elements
   importCsvFile: null,
   importJsonFile: null,
   importExcelFile: null,
+  importProgress: null,
+  importProgressText: null,
 
   // Export elements
   exportCsvBtn: null,
@@ -120,24 +120,16 @@ const elements = {
   clearSearchBtn: null,
   searchResultsInfo: null,
 
-  // Theme toggle
-  themeToggle: null,
-
   // About & acknowledgment modal elements
   aboutBtn: null,
   aboutModal: null,
   ackModal: null,
   ackAcceptBtn: null,
 
-  // API elements
-  apiBtn: null,
-  apiModal: null,
-  apiModalContent: null,
-  apiProviderSelect: null,
-  apiKeyInput: null,
-  apiSaveBtn: null,
-  apiCancelBtn: null,
-  apiStatusDisplay: null,
+  // Settings & API elements
+  settingsBtn: null,
+  settingsModal: null,
+  apiInfoModal: null,
 
   // Spot price action buttons
   spotSyncBtn: null,
@@ -147,16 +139,16 @@ const elements = {
   // Totals display elements (organized by metal type)
   totals: {
     silver: {
-      items: null,       // Total item count
-      weight: null,      // Total weight in ounces
-      value: null,       // Current market value
-      purchased: null,   // Total purchase price
-      avgPrice: null,    // Average price per ounce
-      avgPremium: null,  // Average premium per ounce
-      avgCollectablePrice: null,    // Average collectable price per ounce
+      items: null, // Total item count
+      weight: null, // Total weight in ounces
+      value: null, // Current market value
+      purchased: null, // Total purchase price
+      avgPrice: null, // Average price per ounce
+      avgPremium: null, // Average premium per ounce
+      avgCollectablePrice: null, // Average collectable price per ounce
       avgNonCollectablePrice: null, // Average non-collectable price per ounce
-      premium: null,     // Total premium paid
-      lossProfit: null   // Total loss/profit
+      premium: null, // Total premium paid
+      lossProfit: null, // Total loss/profit
     },
     gold: {
       // Same structure as silver
@@ -168,8 +160,8 @@ const elements = {
       avgPremium: null,
       avgCollectablePrice: null,
       avgNonCollectablePrice: null,
-      premium: null,     // Total premium paid
-      lossProfit: null   // Total loss/profit
+      premium: null, // Total premium paid
+      lossProfit: null, // Total loss/profit
     },
     platinum: {
       items: null,
@@ -180,8 +172,8 @@ const elements = {
       avgPremium: null,
       avgCollectablePrice: null,
       avgNonCollectablePrice: null,
-      premium: null,     // Total premium paid
-      lossProfit: null   // Total loss/profit
+      premium: null, // Total premium paid
+      lossProfit: null, // Total loss/profit
     },
     palladium: {
       items: null,
@@ -192,8 +184,8 @@ const elements = {
       avgPremium: null,
       avgCollectablePrice: null,
       avgNonCollectablePrice: null,
-      premium: null,     // Total premium paid
-      lossProfit: null   // Total loss/profit
+      premium: null, // Total premium paid
+      lossProfit: null, // Total loss/profit
     },
     all: {
       // Combined totals for all metals
@@ -205,10 +197,10 @@ const elements = {
       avgPremium: null,
       avgCollectablePrice: null,
       avgNonCollectablePrice: null,
-      premium: null,     // Total premium paid
-      lossProfit: null   // Total loss/profit
-    }
-  }
+      premium: null, // Total premium paid
+      lossProfit: null, // Total loss/profit
+    },
+  },
 };
 
 /** @type {Array} Main inventory data structure */
@@ -219,7 +211,7 @@ let spotPrices = {
   silver: 0,
   gold: 0,
   platinum: 0,
-  palladium: 0
+  palladium: 0,
 };
 
 /** @type {Array} Historical spot price records */

--- a/js/theme.js
+++ b/js/theme.js
@@ -3,24 +3,30 @@
 
 /**
  * Sets application theme and updates localStorage
- * 
- * @param {string} theme - 'dark' or 'light'
+ *
+ * @param {string} theme - 'dark', 'light', or 'system'
  */
 const setTheme = (theme) => {
-  if (theme === 'dark') {
-    document.documentElement.setAttribute('data-theme', 'dark');
-    localStorage.setItem(THEME_KEY, 'dark');
-    if (elements.themeToggle) {
-      elements.themeToggle.textContent = 'Light Mode';
-    }
+  if (theme === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+    localStorage.setItem(THEME_KEY, "dark");
   } else {
-    document.documentElement.removeAttribute('data-theme');
-    localStorage.setItem(THEME_KEY, 'light');
-    if (elements.themeToggle) {
-      elements.themeToggle.textContent = 'Dark Mode';
+    if (theme === "light") {
+      document.documentElement.removeAttribute("data-theme");
+      localStorage.setItem(THEME_KEY, "light");
+    } else {
+      localStorage.removeItem(THEME_KEY);
+      const systemPrefersDark =
+        window.matchMedia &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches;
+      if (systemPrefersDark) {
+        document.documentElement.setAttribute("data-theme", "dark");
+      } else {
+        document.documentElement.removeAttribute("data-theme");
+      }
     }
   }
-  if (typeof renderTable === 'function') {
+  if (typeof renderTable === "function") {
     renderTable();
   }
 };
@@ -30,14 +36,14 @@ const setTheme = (theme) => {
  */
 const initTheme = () => {
   const savedTheme = localStorage.getItem(THEME_KEY);
-  const systemPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const systemPrefersDark =
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
 
   if (savedTheme) {
     setTheme(savedTheme);
-  } else if (systemPrefersDark) {
-    setTheme('dark');
   } else {
-    setTheme('light');
+    setTheme(systemPrefersDark ? "dark" : "light");
   }
 };
 
@@ -45,8 +51,8 @@ const initTheme = () => {
  * Toggles between dark and light themes
  */
 const toggleTheme = () => {
-  const currentTheme = document.documentElement.getAttribute('data-theme');
-  setTheme(currentTheme === 'dark' ? 'light' : 'dark');
+  const currentTheme = document.documentElement.getAttribute("data-theme");
+  setTheme(currentTheme === "dark" ? "light" : "dark");
 };
 
 /**
@@ -54,12 +60,14 @@ const toggleTheme = () => {
  */
 const setupSystemThemeListener = () => {
   if (window.matchMedia) {
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
-      // Only auto-switch if user hasn't set a preference
-      if (!localStorage.getItem(THEME_KEY)) {
-        setTheme(e.matches ? 'dark' : 'light');
-      }
-    });
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", (e) => {
+        // Only auto-switch if user hasn't set a preference
+        if (!localStorage.getItem(THEME_KEY)) {
+          setTheme(e.matches ? "dark" : "light");
+        }
+      });
   }
 };
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -12,23 +12,24 @@ const debugLog = (...args) => {
 };
 /**
  * Returns formatted version string
- * 
+ *
  * @param {string} [prefix='v'] - Prefix to add before version
  * @returns {string} Formatted version string (e.g., "v3.0.1")
  */
-const getVersionString = (prefix = 'v') => `${prefix}${APP_VERSION}`;
+const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
 
 /**
  * Returns full application title with version
- * 
+ *
  * @param {string} [baseTitle='Precious Metals Inventory Tool'] - Base application title
  * @returns {string} Full title with version
  */
-const getAppTitle = (baseTitle = 'Precious Metals Inventory Tool') => `${baseTitle} ${getVersionString()}`;
+const getAppTitle = (baseTitle = "Precious Metals Inventory Tool") =>
+  `${baseTitle} ${getVersionString()}`;
 
 /**
  * Performance monitoring utility
- * 
+ *
  * @param {Function} fn - Function to monitor
  * @param {string} name - Name for logging
  * @param {...any} args - Arguments to pass to function
@@ -38,30 +39,30 @@ const monitorPerformance = (fn, name, ...args) => {
   const startTime = performance.now();
   const result = fn(...args);
   const endTime = performance.now();
-  
+
   const duration = endTime - startTime;
   if (duration > 100) {
     console.warn(`Performance warning: ${name} took ${duration.toFixed(2)}ms`);
   } else {
     debugLog(`Performance: ${name} took ${duration.toFixed(2)}ms`);
   }
-  
+
   return result;
 };
 
 /**
  * Gets the most recent timestamp for a specific metal from spot history
- * 
+ *
  * @param {string} metalName - Metal name ('Silver', 'Gold', 'Platinum', 'Palladium')
  * @returns {string|null} Formatted timestamp or null if no data
  */
 const getLastUpdateTime = (metalName) => {
   if (!spotHistory || spotHistory.length === 0) return null;
-  
+
   // Find the most recent entry for this metal
-  const metalEntries = spotHistory.filter(entry => entry.metal === metalName);
+  const metalEntries = spotHistory.filter((entry) => entry.metal === metalName);
   if (metalEntries.length === 0) return null;
-  
+
   const latestEntry = metalEntries[metalEntries.length - 1];
   const timestamp = new Date(latestEntry.timestamp);
   const now = new Date();
@@ -69,25 +70,35 @@ const getLastUpdateTime = (metalName) => {
   const diffMins = Math.floor(diffMs / (1000 * 60));
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-  
+
   let timeText;
   if (diffMins < 1) {
-    timeText = 'Just now';
+    timeText = "Just now";
   } else if (diffMins < 60) {
-    timeText = `${diffMins} min${diffMins === 1 ? '' : 's'} ago`;
+    timeText = `${diffMins} min${diffMins === 1 ? "" : "s"} ago`;
   } else if (diffHours < 24) {
-    timeText = `${diffHours} hr${diffHours === 1 ? '' : 's'} ago`;
+    timeText = `${diffHours} hr${diffHours === 1 ? "" : "s"} ago`;
   } else if (diffDays < 30) {
-    timeText = `${diffDays} day${diffDays === 1 ? '' : 's'} ago`;
+    timeText = `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
   } else {
     timeText = timestamp.toLocaleDateString();
   }
-  
-  const sourceText = latestEntry.source === 'api' ? 'API' : 
-                    latestEntry.source === 'manual' ? 'Manual' :
-                    latestEntry.source === 'cached' ? 'Cached' :
-                    latestEntry.source === 'default' ? 'Default' : 'Stored';
-  
+
+  let sourceText;
+  if (latestEntry.source === "api") {
+    sourceText = latestEntry.provider || "API";
+  } else if (latestEntry.source === "cached") {
+    sourceText = latestEntry.provider
+      ? `${latestEntry.provider} (cached)`
+      : "Cached";
+  } else if (latestEntry.source === "manual") {
+    sourceText = "Manual";
+  } else if (latestEntry.source === "default") {
+    sourceText = "Default";
+  } else {
+    sourceText = "Stored";
+  }
+
   return `${timeText} (${sourceText})`;
 };
 
@@ -95,35 +106,35 @@ const getLastUpdateTime = (metalName) => {
 
 /**
  * Pads a number with leading zeros to ensure two-digit format
- * 
+ *
  * @param {number} n - Number to pad
  * @returns {string} Two-digit string representation
  * @example pad2(5) returns "05", pad2(12) returns "12"
  */
-const pad2 = n => n.toString().padStart(2, '0');
+const pad2 = (n) => n.toString().padStart(2, "0");
 
 /**
  * Returns current date as ISO string (YYYY-MM-DD)
- * 
+ *
  * @returns {string} Current date in ISO format
  */
 const todayStr = () => {
   const d = new Date();
-  return `${d.getFullYear()}-${pad2(d.getMonth()+1)}-${pad2(d.getDate())}`;
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
 };
 
 /**
  * Parses various date formats into standard YYYY-MM-DD format
- * 
+ *
  * Handles:
  * - ISO format (YYYY-MM-DD)
  * - US format (MM/DD/YYYY)
  * - European format (DD/MM/YYYY)
  * - Year-first format (YYYY/MM/DD)
- * 
+ *
  * Uses intelligent parsing to distinguish between US and European formats
  * based on date values and context clues.
- * 
+ *
  * @param {string} dateStr - Date string in any supported format
  * @returns {string} Date in YYYY-MM-DD format, or today's date if parsing fails
  */
@@ -136,13 +147,15 @@ function parseDate(dateStr) {
   // Try ISO format (YYYY-MM-DD) first - most reliable
   if (/^\d{4}-\d{2}-\d{2}$/.test(cleanDateStr)) {
     const date = new Date(cleanDateStr);
-    if (!isNaN(date) && date.toString() !== 'Invalid Date') {
+    if (!isNaN(date) && date.toString() !== "Invalid Date") {
       return cleanDateStr;
     }
   }
 
   // Try YYYY/MM/DD format (unambiguous)
-  const ymdMatch = cleanDateStr.match(/^(\d{4})[\/\-](\d{1,2})[\/\-](\d{1,2})$/);
+  const ymdMatch = cleanDateStr.match(
+    /^(\d{4})[\/\-](\d{1,2})[\/\-](\d{1,2})$/,
+  );
   if (ymdMatch) {
     const year = parseInt(ymdMatch[1], 10);
     const month = parseInt(ymdMatch[2], 10) - 1;
@@ -150,14 +163,16 @@ function parseDate(dateStr) {
 
     if (month >= 0 && month <= 11 && day >= 1 && day <= 31) {
       const date = new Date(year, month, day);
-      if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-        return date.toISOString().split('T')[0];
+      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+        return date.toISOString().split("T")[0];
       }
     }
   }
 
   // Handle ambiguous MM/DD/YYYY vs DD/MM/YYYY formats
-  const ambiguousMatch = cleanDateStr.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/);
+  const ambiguousMatch = cleanDateStr.match(
+    /^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/,
+  );
   if (ambiguousMatch) {
     const first = parseInt(ambiguousMatch[1], 10);
     const second = parseInt(ambiguousMatch[2], 10);
@@ -166,29 +181,29 @@ function parseDate(dateStr) {
     // If first number > 12, it must be DD/MM/YYYY (European)
     if (first > 12 && second <= 12) {
       const date = new Date(year, second - 1, first);
-      if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-        return date.toISOString().split('T')[0];
+      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+        return date.toISOString().split("T")[0];
       }
     }
     // If second number > 12, it must be MM/DD/YYYY (US)
     else if (second > 12 && first <= 12) {
       const date = new Date(year, first - 1, second);
-      if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-        return date.toISOString().split('T')[0];
+      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+        return date.toISOString().split("T")[0];
       }
     }
     // Both numbers <= 12, ambiguous - default to US format (MM/DD/YYYY)
     else if (first <= 12 && second <= 12) {
       // Try US format first
       let date = new Date(year, first - 1, second);
-      if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-        return date.toISOString().split('T')[0];
+      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+        return date.toISOString().split("T")[0];
       }
-      
+
       // Fallback to European format
       date = new Date(year, second - 1, first);
-      if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-        return date.toISOString().split('T')[0];
+      if (!isNaN(date) && date.toString() !== "Invalid Date") {
+        return date.toISOString().split("T")[0];
       }
     }
   }
@@ -196,8 +211,8 @@ function parseDate(dateStr) {
   // Try parsing as a general date string (fallback)
   try {
     const date = new Date(cleanDateStr);
-    if (!isNaN(date) && date.toString() !== 'Invalid Date') {
-      return date.toISOString().split('T')[0];
+    if (!isNaN(date) && date.toString() !== "Invalid Date") {
+      return date.toISOString().split("T")[0];
     }
   } catch (e) {
     // Continue to fallback
@@ -217,7 +232,11 @@ function parseDate(dateStr) {
 const formatDisplayDate = (dateStr) => {
   const d = new Date(dateStr);
   if (isNaN(d)) return dateStr;
-  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 };
 
 /**
@@ -226,11 +245,11 @@ const formatDisplayDate = (dateStr) => {
  * @param {number|string} n - Number to format
  * @returns {string} Formatted dollar string (e.g., "$1,234.56")
  */
-const formatDollar = n => `$${parseFloat(n).toFixed(2)}`;
+const formatDollar = (n) => `$${parseFloat(n).toFixed(2)}`;
 
 /**
  * Formats a profit/loss value with color coding
- * 
+ *
  * @param {number} value - Profit/loss value
  * @returns {string} HTML string with appropriate color styling
  */
@@ -247,20 +266,20 @@ const formatLossProfit = (value) => {
 /**
  * Sanitizes text input for safe HTML display
  * Prevents XSS attacks by encoding HTML special characters
- * 
+ *
  * @param {string} text - Text to sanitize
  * @returns {string} Sanitized text safe for HTML insertion
  */
 const sanitizeHtml = (text) => {
-  if (!text) return '';
-  const div = document.createElement('div');
+  if (!text) return "";
+  const div = document.createElement("div");
   div.textContent = text.toString();
   return div.innerHTML;
 };
 
 /**
  * Saves data to localStorage with JSON serialization
- * 
+ *
  * @param {string} key - Storage key
  * @param {any} data - Data to store
  */
@@ -268,7 +287,7 @@ const saveData = (key, data) => localStorage.setItem(key, JSON.stringify(data));
 
 /**
  * Loads data from localStorage with error handling
- * 
+ *
  * @param {string} key - Storage key
  * @param {any} [defaultValue=[]] - Default value if no data found
  * @returns {any} Parsed data or default value
@@ -283,7 +302,7 @@ const loadData = (key, defaultValue = []) => {
 
 /**
  * Sorts inventory by date (newest first)
- * 
+ *
  * @param {Array} [data=inventory] - Data to sort
  * @returns {Array} Sorted inventory data
  */
@@ -297,63 +316,75 @@ const sortInventoryByDateNewestFirst = (data = inventory) => {
 
 /**
  * Validates inventory item data
- * 
+ *
  * @param {Object} item - Inventory item to validate
  * @returns {Object} Validation result with isValid flag and errors array
  */
 const validateInventoryItem = (item) => {
   const errors = [];
-  
+
   // Required fields
-  if (!item.name || typeof item.name !== 'string' || item.name.trim().length === 0) {
-    errors.push('Name is required');
+  if (
+    !item.name ||
+    typeof item.name !== "string" ||
+    item.name.trim().length === 0
+  ) {
+    errors.push("Name is required");
   } else if (item.name.length > 100) {
-    errors.push('Name must be 100 characters or less');
+    errors.push("Name must be 100 characters or less");
   }
-  
-  if (!item.metal || !['Silver', 'Gold', 'Platinum', 'Palladium'].includes(item.metal)) {
-    errors.push('Valid metal type is required');
+
+  if (
+    !item.metal ||
+    !["Silver", "Gold", "Platinum", "Palladium"].includes(item.metal)
+  ) {
+    errors.push("Valid metal type is required");
   }
-  
+
   // Numeric validations
-  if (!item.qty || !Number.isInteger(Number(item.qty)) || Number(item.qty) < 1) {
-    errors.push('Quantity must be a positive integer');
+  if (
+    !item.qty ||
+    !Number.isInteger(Number(item.qty)) ||
+    Number(item.qty) < 1
+  ) {
+    errors.push("Quantity must be a positive integer");
   }
-  
+
   if (!item.weight || isNaN(Number(item.weight)) || Number(item.weight) <= 0) {
-    errors.push('Weight must be a positive number');
+    errors.push("Weight must be a positive number");
   }
-  
+
   if (!item.price || isNaN(Number(item.price)) || Number(item.price) <= 0) {
-    errors.push('Price must be a positive number');
+    errors.push("Price must be a positive number");
   }
-  
+
   // Optional field validations
   if (item.storageLocation && item.storageLocation.length > 50) {
-    errors.push('Storage location must be 50 characters or less');
+    errors.push("Storage location must be 50 characters or less");
   }
-  
+
   if (item.purchaseLocation && item.purchaseLocation.length > 100) {
-    errors.push('Purchase location must be 100 characters or less');
+    errors.push("Purchase location must be 100 characters or less");
   }
-  
+
   return {
     isValid: errors.length === 0,
-    errors
+    errors,
   };
 };
 
 /**
  * Handles errors with user-friendly messaging
- * 
+ *
  * @param {Error|string} error - Error to handle
  * @param {string} context - Context where error occurred
  */
-const handleError = (error, context = '') => {
-  const errorMessage = error instanceof Error ? error.message : error.toString();
-  
+const handleError = (error, context = "") => {
+  const errorMessage =
+    error instanceof Error ? error.message : error.toString();
+
   console.error(`Error in ${context}:`, error);
-  
+
   // Show user-friendly message
   const userMessage = getUserFriendlyMessage(errorMessage);
   alert(`Error: ${userMessage}`);
@@ -361,51 +392,51 @@ const handleError = (error, context = '') => {
 
 /**
  * Converts technical error messages to user-friendly ones
- * 
+ *
  * @param {string} errorMessage - Technical error message
  * @returns {string} User-friendly error message
  */
 const getUserFriendlyMessage = (errorMessage) => {
-  if (errorMessage.includes('localStorage')) {
-    return 'Unable to save data. Please check your browser settings.';
+  if (errorMessage.includes("localStorage")) {
+    return "Unable to save data. Please check your browser settings.";
   }
-  if (errorMessage.includes('parse') || errorMessage.includes('JSON')) {
-    return 'The file format is not supported or corrupted.';
+  if (errorMessage.includes("parse") || errorMessage.includes("JSON")) {
+    return "The file format is not supported or corrupted.";
   }
-  if (errorMessage.includes('network') || errorMessage.includes('fetch')) {
-    return 'Network connection issue. Please check your internet connection.';
+  if (errorMessage.includes("network") || errorMessage.includes("fetch")) {
+    return "Network connection issue. Please check your internet connection.";
   }
-  
+
   // Default fallback
-  return errorMessage || 'An unexpected error occurred.';
+  return errorMessage || "An unexpected error occurred.";
 };
 
 /**
  * Downloads a file with the specified content and filename
- * 
+ *
  * @param {string} filename - Name of the file to download
  * @param {string} content - Content of the file
  * @param {string} mimeType - MIME type of the file (default: text/plain)
  */
-const downloadFile = (filename, content, mimeType = 'text/plain') => {
+const downloadFile = (filename, content, mimeType = "text/plain") => {
   try {
     const blob = new Blob([content], { type: mimeType });
     const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    
+    const link = document.createElement("a");
+
     link.href = url;
     link.download = filename;
-    link.style.display = 'none';
-    
+    link.style.display = "none";
+
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    
+
     // Clean up the object URL after a short delay
     setTimeout(() => URL.revokeObjectURL(url), 1000);
   } catch (error) {
-    console.error('Error downloading file:', error);
-    handleError(error, 'file download');
+    console.error("Error downloading file:", error);
+    handleError(error, "file download");
   }
 };
 


### PR DESCRIPTION
## Summary
- style header with icon-only About and Settings buttons
- organize settings into framed sections including Appearance, API, Files, and a pirate-themed reset
- add configurable custom API provider with base URL, endpoint, and metal format options

## Testing
- `npx --yes prettier --check index.html css/styles.css js/api.js js/constants.js js/events.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689692e7656c832ea86c15fd43a335ec