### PR TITLE
feat: enhance settings and api history

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,8 +10,10 @@
   --secondary: #64748b;
   --secondary-hover: #475569;
   --success: #059669;
+  --success-hover: #047857;
   --info: #0ea5e9;
   --warning: #d97706;
+  --warning-hover: #b45309;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
 
@@ -58,7 +60,13 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --success: #10b981;
+  --success-hover: #059669;
   --info: #38bdf8;
+  --warning: #f59e0b;
+  --warning-hover: #d97706;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
 
   /* Metal-specific Colors - dark mode */
   --silver: #d1d5db;
@@ -333,6 +341,23 @@ input[type="submit"] {
   background: var(--danger-hover);
 }
 
+.btn.success {
+  background: var(--success);
+}
+
+.btn.success:hover {
+  background: var(--success-hover);
+}
+
+.btn.warning {
+  background: var(--warning);
+  color: var(--text-primary);
+}
+
+.btn.warning:hover {
+  background: var(--warning-hover);
+}
+
 .btn.premium {
   background: var(--warning);
   color: var(--text-primary);
@@ -521,6 +546,49 @@ input[type="submit"] {
   gap: 0.25rem;
 }
 
+.provider-history {
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}
+
+.provider-history table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.provider-history td {
+  padding: 0.1rem 0.25rem;
+}
+
+.provider-default-btn {
+  min-width: 80px;
+}
+
+.provider-default-btn.default {
+  background: var(--success);
+}
+
+.provider-default-btn.default:hover {
+  background: var(--success-hover);
+}
+
+.provider-default-btn.backup {
+  background: var(--warning);
+  color: var(--text-primary);
+}
+
+.provider-default-btn.backup:hover {
+  background: var(--warning-hover);
+}
+
+.provider-default-btn.inactive {
+  background: var(--secondary);
+}
+
+.provider-default-btn.inactive:hover {
+  background: var(--secondary-hover);
+}
+
 .cache-duration-row {
   display: flex;
   align-items: center;
@@ -586,6 +654,23 @@ input[type="submit"] {
   display: flex;
   gap: 1rem;
   margin-top: 0.5rem;
+}
+
+.theme-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.theme-icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
 }
 
 /* Info modal sizing */

--- a/index.html
+++ b/index.html
@@ -68,16 +68,16 @@
     <div class="app-header">
       <h1>Precious Metals Inventory Tool</h1>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button class="btn" id="aboutBtn" title="About" aria-label="About">
-          📖
-        </button>
         <button
           class="btn"
           id="settingsBtn"
           title="Settings"
           aria-label="Settings"
         >
-          ⚙️
+          Settings ⚙️
+        </button>
+        <button class="btn" id="aboutBtn" title="About" aria-label="About">
+          About 📖
         </button>
       </div>
     </div>
@@ -1232,24 +1232,6 @@
         </div>
         <div class="modal-body">
           <div class="settings-section">
-            <h3>Appearance</h3>
-            <div class="theme-options">
-              <label
-                ><input type="radio" name="themePreference" value="light" />
-                Light Default</label
-              >
-              <label
-                ><input type="radio" name="themePreference" value="dark" /> Dark
-                Default</label
-              >
-              <label
-                ><input type="radio" name="themePreference" value="system" />
-                Follow System</label
-              >
-            </div>
-          </div>
-
-          <div class="settings-section">
             <h3 style="margin-bottom: 1rem">API Configuration</h3>
 
             <div class="api-providers">
@@ -1278,31 +1260,30 @@
                       <span class="status-dot"></span>
                       <span class="status-text">Disconnected</span>
                     </div>
+                    <div class="provider-history"></div>
                   </div>
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METALS_DEV"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METALS_DEV"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METALS_DEV"
-                        checked
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METALS_DEV"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1332,30 +1313,30 @@
                       <span class="status-dot"></span>
                       <span class="status-text">Disconnected</span>
                     </div>
+                    <div class="provider-history"></div>
                   </div>
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METALS_API"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METALS_API"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METALS_API"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METALS_API"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1391,30 +1372,30 @@
                       <span class="status-dot"></span>
                       <span class="status-text">Disconnected</span>
                     </div>
+                    <div class="provider-history"></div>
                   </div>
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METAL_PRICE_API"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METAL_PRICE_API"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METAL_PRICE_API"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METAL_PRICE_API"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1463,30 +1444,30 @@
                       <span class="status-dot"></span>
                       <span class="status-text">Disconnected</span>
                     </div>
+                    <div class="provider-history"></div>
                   </div>
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="CUSTOM"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="CUSTOM"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="CUSTOM"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="CUSTOM"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1504,9 +1485,28 @@
             </div>
 
             <div class="settings-actions">
-              <button type="button" class="btn" id="clearApiCacheBtn">
+              <button type="button" class="btn danger" id="clearApiCacheBtn">
                 Clear API Cache
               </button>
+              <button type="button" class="btn" id="apiHistoryBtn">History</button>
+            </div>
+          </div>
+
+          <div class="settings-section">
+            <h3>Appearance</h3>
+            <div class="theme-options">
+              <label class="theme-option"
+                ><input type="radio" name="themePreference" value="light" />
+                <span class="theme-icon">☀️</span><span>Light</span></label
+              >
+              <label class="theme-option"
+                ><input type="radio" name="themePreference" value="dark" />
+                <span class="theme-icon">🌙</span><span>Dark</span></label
+              >
+              <label class="theme-option"
+                ><input type="radio" name="themePreference" value="system" />
+                <span class="theme-icon">💻</span><span>System</span></label
+              >
             </div>
           </div>
 
@@ -1530,6 +1530,21 @@
         <div id="apiInfoBody" class="api-info-body"></div>
         <div class="modal-footer">
           <button type="button" class="btn" id="apiInfoCloseBtn">Close</button>
+        </div>
+      </div>
+    </div>
+    <div class="modal" id="apiHistoryModal" style="display: none">
+      <div class="modal-content">
+        <h3>API Price History</h3>
+        <div class="api-history-body">
+          <table id="apiHistoryTable"></table>
+          <canvas id="apiHistoryChart"></canvas>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn" id="clearHistoryBtn">
+            Clear History
+          </button>
+          <button type="button" class="btn" id="apiHistoryCloseBtn">Close</button>
         </div>
       </div>
     </div>

--- a/js/api.js
+++ b/js/api.js
@@ -147,13 +147,147 @@ const setProviderStatus = (provider, status) => {
 };
 
 /**
+ * Updates provider history tables with latest API values
+ */
+const updateProviderHistoryTables = () => {
+  loadSpotHistory();
+  const history = spotHistory.filter((e) => e.source === "api");
+  Object.keys(API_PROVIDERS).forEach((prov) => {
+    const container = document.querySelector(
+      `.api-provider[data-provider="${prov}"] .provider-history`,
+    );
+    if (!container) return;
+    const providerName = API_PROVIDERS[prov].name;
+    const metals = ["Silver", "Gold", "Platinum", "Palladium"];
+    let html = "<table>";
+    metals.forEach((metal) => {
+      const entries = history.filter(
+        (e) => e.provider === providerName && e.metal === metal,
+      );
+      const last = entries.length
+        ? formatDollar(entries[entries.length - 1].spot)
+        : "-";
+      html += `<tr><td>${metal}</td><td>${last}</td></tr>`;
+    });
+    html += "</table>";
+    container.innerHTML = html;
+  });
+};
+
+/**
+ * Updates default provider button states
+ */
+const updateDefaultProviderButtons = () => {
+  const config = loadApiConfig();
+  const keys = config.keys || {};
+  const active = Object.keys(API_PROVIDERS).filter((p) => keys[p]);
+  if (active.length === 1) {
+    config.provider = active[0];
+    saveApiConfig(config);
+  }
+  Object.keys(API_PROVIDERS).forEach((prov) => {
+    const btn = document.querySelector(
+      `.provider-default-btn[data-provider="${prov}"]`,
+    );
+    if (!btn) return;
+    btn.classList.remove("default", "backup", "inactive");
+    if (config.provider === prov && keys[prov]) {
+      btn.textContent = "Default";
+      btn.classList.add("default");
+    } else if (keys[prov]) {
+      btn.textContent = "Backup";
+      btn.classList.add("backup");
+    } else {
+      btn.textContent = "Not in use";
+      btn.classList.add("inactive");
+    }
+  });
+};
+
+/**
+ * Shows API history modal with table and chart
+ */
+const showApiHistoryModal = () => {
+  const modal = document.getElementById("apiHistoryModal");
+  if (!modal) return;
+  loadSpotHistory();
+  const entries = spotHistory.filter((e) => e.source === "api");
+  const table = document.getElementById("apiHistoryTable");
+  if (table) {
+    let rows =
+      "<tr><th>Time</th><th>Metal</th><th>Price</th><th>API</th></tr>";
+    entries.forEach((e) => {
+      rows += `<tr><td>${e.timestamp}</td><td>${e.metal}</td><td>${formatDollar(
+        e.spot,
+      )}</td><td>${e.provider || ""}</td></tr>`;
+    });
+    table.innerHTML = rows;
+  }
+  const ctx = document.getElementById("apiHistoryChart");
+  if (ctx) {
+    const metals = ["Silver", "Gold", "Platinum", "Palladium"];
+    const datasets = [];
+    let maxLen = 0;
+    metals.forEach((metal) => {
+      const data = entries
+        .filter((e) => e.metal === metal)
+        .slice(-30)
+        .map((e) => e.spot);
+      if (data.length > maxLen) maxLen = data.length;
+      const color = getComputedStyle(document.documentElement).getPropertyValue(
+        `--${metal.toLowerCase()}`,
+      );
+      datasets.push({
+        label: metal,
+        data,
+        borderColor: color,
+        tension: 0.2,
+      });
+    });
+    const labels = Array.from({ length: maxLen }, (_, i) => i + 1);
+    if (chartInstances.apiHistoryChart) {
+      chartInstances.apiHistoryChart.destroy();
+    }
+    chartInstances.apiHistoryChart = new Chart(ctx, {
+      type: "line",
+      data: { labels, datasets },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+  }
+  modal.style.display = "flex";
+};
+
+/**
+ * Hides API history modal
+ */
+const hideApiHistoryModal = () => {
+  const modal = document.getElementById("apiHistoryModal");
+  if (modal) modal.style.display = "none";
+};
+
+/**
+ * Clears stored API price history
+ */
+const clearApiHistory = () => {
+  spotHistory = [];
+  saveSpotHistory();
+  updateProviderHistoryTables();
+  showApiHistoryModal();
+};
+
+/**
  * Updates default provider selection in config
  * @param {string} provider
  */
 const setDefaultProvider = (provider) => {
   const config = loadApiConfig();
+  if (!config.keys[provider]) {
+    alert("Please enter your API key first");
+    return;
+  }
   config.provider = provider;
   saveApiConfig(config);
+  updateDefaultProviderButtons();
   updateSyncButtonStates();
 };
 
@@ -164,6 +298,13 @@ const setDefaultProvider = (provider) => {
 const clearApiKey = (provider) => {
   const config = loadApiConfig();
   delete config.keys[provider];
+  if (config.provider === provider) {
+    config.provider = "";
+  }
+  const active = Object.keys(API_PROVIDERS).filter((p) => config.keys[p]);
+  if (active.length === 1) {
+    config.provider = active[0];
+  }
   saveApiConfig(config);
   const input = document.getElementById(`apiKey_${provider}`);
   if (input) input.value = "";
@@ -178,6 +319,8 @@ const clearApiKey = (provider) => {
     saveApiConfig(config);
   }
   setProviderStatus(provider, "disconnected");
+  updateDefaultProviderButtons();
+  updateProviderHistoryTables();
 };
 
 /**
@@ -572,9 +715,6 @@ const testApiConnection = async (provider, apiKey) => {
  */
 const handleProviderSync = async (provider) => {
   const keyInput = document.getElementById(`apiKey_${provider}`);
-  const radio = document.querySelector(
-    `input[name="defaultProvider"][value="${provider}"]`,
-  );
   if (!keyInput) return;
 
   const apiKey = keyInput.value.trim();
@@ -597,11 +737,9 @@ const handleProviderSync = async (provider) => {
     }
     config.customConfig = { baseUrl: base, endpoint, format };
   }
-  if (radio && radio.checked) {
-    config.provider = provider;
-  }
   config.timestamp = new Date().getTime();
   saveApiConfig(config);
+  updateDefaultProviderButtons();
   updateSyncButtonStates();
   setProviderStatus(provider, "disconnected");
 
@@ -640,6 +778,7 @@ const handleProviderSync = async (provider) => {
       saveApiCache(data, provider);
       updateSummary();
       setProviderStatus(provider, "connected");
+      updateProviderHistoryTables();
       alert(
         `Successfully synced ${updatedCount} metal prices from ${API_PROVIDERS[provider].name}`,
       );
@@ -705,11 +844,7 @@ const showSettingsModal = () => {
 
   Object.keys(API_PROVIDERS).forEach((prov) => {
     const input = document.getElementById(`apiKey_${prov}`);
-    const radio = document.querySelector(
-      `input[name="defaultProvider"][value="${prov}"]`,
-    );
     if (input) input.value = currentConfig.keys?.[prov] || "";
-    if (radio) radio.checked = currentConfig.provider === prov;
     setProviderStatus(prov, providerStatuses[prov] || "disconnected");
   });
 
@@ -726,7 +861,8 @@ const showSettingsModal = () => {
   if (durationSelect) {
     durationSelect.value = String(currentConfig.cacheHours ?? 24);
   }
-
+  updateDefaultProviderButtons();
+  updateProviderHistoryTables();
   modal.style.display = "flex";
 };
 
@@ -796,6 +932,9 @@ window.clearApiKey = clearApiKey;
 window.clearApiCache = clearApiCache;
 window.setDefaultProvider = setDefaultProvider;
 window.setCacheDuration = setCacheDuration;
+window.showApiHistoryModal = showApiHistoryModal;
+window.hideApiHistoryModal = hideApiHistoryModal;
+window.clearApiHistory = clearApiHistory;
 
 /**
  * Shows manual price input for a specific metal

--- a/js/events.js
+++ b/js/events.js
@@ -1118,21 +1118,19 @@ const setupApiEvents = () => {
       );
     }
 
-    document
-      .querySelectorAll('input[name="defaultProvider"]')
-      .forEach((radio) => {
-        const provider = radio.value;
-        safeAttachListener(
-          radio,
-          "change",
-          () => {
-            if (radio.checked && typeof setDefaultProvider === "function") {
-              setDefaultProvider(provider);
-            }
-          },
-          "Default provider radio",
-        );
-      });
+    document.querySelectorAll(".provider-default-btn").forEach((btn) => {
+      const provider = btn.getAttribute("data-provider");
+      safeAttachListener(
+        btn,
+        "click",
+        () => {
+          if (typeof setDefaultProvider === "function") {
+            setDefaultProvider(provider);
+          }
+        },
+        "Default provider button",
+      );
+    });
 
     const clearCacheBtn = document.getElementById("clearApiCacheBtn");
     if (clearCacheBtn) {
@@ -1148,6 +1146,60 @@ const setupApiEvents = () => {
       );
     }
 
+    const historyBtn = document.getElementById("apiHistoryBtn");
+    if (historyBtn) {
+      safeAttachListener(
+        historyBtn,
+        "click",
+        () => {
+          if (typeof showApiHistoryModal === "function") {
+            showApiHistoryModal();
+          }
+        },
+        "API history button",
+      );
+    }
+
+    const historyModal = document.getElementById("apiHistoryModal");
+    const historyCloseBtn = document.getElementById("apiHistoryCloseBtn");
+    const clearHistoryBtn = document.getElementById("clearHistoryBtn");
+    if (historyModal) {
+      safeAttachListener(
+        historyModal,
+        "click",
+        (e) => {
+          if (e.target === historyModal && typeof hideApiHistoryModal === "function") {
+            hideApiHistoryModal();
+          }
+        },
+        "API history modal background",
+      );
+    }
+    if (historyCloseBtn) {
+      safeAttachListener(
+        historyCloseBtn,
+        "click",
+        () => {
+          if (typeof hideApiHistoryModal === "function") {
+            hideApiHistoryModal();
+          }
+        },
+        "API history close button",
+      );
+    }
+    if (clearHistoryBtn) {
+      safeAttachListener(
+        clearHistoryBtn,
+        "click",
+        () => {
+          if (typeof clearApiHistory === "function") {
+            clearApiHistory();
+          }
+        },
+        "Clear API history button",
+      );
+    }
+
     // ESC key to close modals
     safeAttachListener(
       document,
@@ -1156,6 +1208,7 @@ const setupApiEvents = () => {
         if (e.key === "Escape") {
           const settingsModal = document.getElementById("settingsModal");
           const infoModal = document.getElementById("apiInfoModal");
+          const historyModal = document.getElementById("apiHistoryModal");
           const editModal = document.getElementById("editModal");
           const detailsModal = document.getElementById("detailsModal");
 
@@ -1171,6 +1224,12 @@ const setupApiEvents = () => {
             typeof hideProviderInfo === "function"
           ) {
             hideProviderInfo();
+          } else if (
+            historyModal &&
+            historyModal.style.display === "flex" &&
+            typeof hideApiHistoryModal === "function"
+          ) {
+            hideApiHistoryModal();
           } else if (editModal && editModal.style.display === "flex") {
             editModal.style.display = "none";
             editingIndex = null;

--- a/js/init.js
+++ b/js/init.js
@@ -98,6 +98,7 @@ document.addEventListener("DOMContentLoaded", () => {
     debugLog("Phase 4: Initializing modal elements...");
     elements.settingsModal = safeGetElement("settingsModal");
     elements.apiInfoModal = safeGetElement("apiInfoModal");
+    elements.apiHistoryModal = safeGetElement("apiHistoryModal");
     elements.aboutModal = safeGetElement("aboutModal");
     elements.ackModal = safeGetElement("ackModal");
     elements.ackAcceptBtn = safeGetElement("ackAcceptBtn");

--- a/js/spot.js
+++ b/js/spot.js
@@ -53,7 +53,12 @@ const fetchSpotPrice = () => {
           spotPrices[metalConfig.key],
         );
       }
-      recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
+      const hasHistory = spotHistory.some(
+        (e) => e.metal === metalConfig.name,
+      );
+      if (!hasHistory) {
+        recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
+      }
     } else {
       // Use default price if no stored price
       const defaultPrice = metalConfig.defaultPrice;

--- a/js/state.js
+++ b/js/state.js
@@ -24,6 +24,7 @@ let columnFilter = { field: null, value: null };
 let chartInstances = {
   typeChart: null,
   locationChart: null,
+  apiHistoryChart: null,
 };
 
 /** @type {Object} Cached DOM elements for performance */
@@ -130,6 +131,7 @@ const elements = {
   settingsBtn: null,
   settingsModal: null,
   apiInfoModal: null,
+  apiHistoryModal: null,
 
   // Spot price action buttons
   spotSyncBtn: null,


### PR DESCRIPTION
## Summary
- swap Settings/About buttons and restore labels
- redesign API defaults with colored buttons and add History modal
- move theme settings, add icons, and show provider price tables

## Testing
- `node --check js/api.js`
- `node --check js/events.js`
- `node --check js/spot.js`
- `node --check js/state.js`
- `node --check js/init.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896b68274d8832e82ff9248ca692c37