### PR TITLE
feat: refine settings appearance and history export

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10,8 +10,10 @@
   --secondary: #64748b;
   --secondary-hover: #475569;
   --success: #059669;
+  --success-hover: #047857;
   --info: #0ea5e9;
   --warning: #d97706;
+  --warning-hover: #b45309;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
 
@@ -58,7 +60,13 @@
   --primary-hover: #2563eb;
   --secondary: #6b7280;
   --secondary-hover: #9ca3af;
+  --success: #10b981;
+  --success-hover: #059669;
   --info: #38bdf8;
+  --warning: #f59e0b;
+  --warning-hover: #d97706;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
 
   /* Metal-specific Colors - dark mode */
   --silver: #d1d5db;
@@ -333,6 +341,23 @@ input[type="submit"] {
   background: var(--danger-hover);
 }
 
+.btn.success {
+  background: var(--success);
+}
+
+.btn.success:hover {
+  background: var(--success-hover);
+}
+
+.btn.warning {
+  background: var(--warning);
+  color: var(--text-primary);
+}
+
+.btn.warning:hover {
+  background: var(--warning-hover);
+}
+
 .btn.premium {
   background: var(--warning);
   color: var(--text-primary);
@@ -521,6 +546,50 @@ input[type="submit"] {
   gap: 0.25rem;
 }
 
+.provider-history {
+  font-size: 0.75rem;
+  margin: 0.25rem 0;
+}
+
+.provider-history table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.provider-history td {
+  padding: 0.1rem 0.25rem;
+  white-space: nowrap;
+}
+
+.provider-default-btn {
+  min-width: 80px;
+}
+
+.provider-default-btn.default {
+  background: var(--success);
+}
+
+.provider-default-btn.default:hover {
+  background: var(--success-hover);
+}
+
+.provider-default-btn.backup {
+  background: var(--warning);
+  color: var(--text-primary);
+}
+
+.provider-default-btn.backup:hover {
+  background: var(--warning-hover);
+}
+
+.provider-default-btn.inactive {
+  background: var(--secondary);
+}
+
+.provider-default-btn.inactive:hover {
+  background: var(--secondary-hover);
+}
+
 .cache-duration-row {
   display: flex;
   align-items: center;
@@ -580,12 +649,32 @@ input[type="submit"] {
   margin-top: 1rem;
   display: flex;
   justify-content: flex-end;
+  gap: 1rem;
 }
 
 .theme-options {
   display: flex;
   gap: 1rem;
   margin-top: 0.5rem;
+}
+
+.theme-btn {
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.theme-btn.active {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: #fff;
 }
 
 /* Info modal sizing */
@@ -597,9 +686,10 @@ input[type="submit"] {
   margin-bottom: 1rem;
 }
 
-#apiInfoModal .modal-footer {
+.modal-footer {
   display: flex;
   justify-content: flex-end;
+  gap: 0.5rem;
   margin-top: 1.5rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -68,16 +68,16 @@
     <div class="app-header">
       <h1>Precious Metals Inventory Tool</h1>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button class="btn" id="aboutBtn" title="About" aria-label="About">
-          📖
-        </button>
         <button
           class="btn"
           id="settingsBtn"
           title="Settings"
           aria-label="Settings"
         >
-          ⚙️
+          Settings ⚙️
+        </button>
+        <button class="btn" id="aboutBtn" title="About" aria-label="About">
+          About 📖
         </button>
       </div>
     </div>
@@ -1232,24 +1232,6 @@
         </div>
         <div class="modal-body">
           <div class="settings-section">
-            <h3>Appearance</h3>
-            <div class="theme-options">
-              <label
-                ><input type="radio" name="themePreference" value="light" />
-                Light Default</label
-              >
-              <label
-                ><input type="radio" name="themePreference" value="dark" /> Dark
-                Default</label
-              >
-              <label
-                ><input type="radio" name="themePreference" value="system" />
-                Follow System</label
-              >
-            </div>
-          </div>
-
-          <div class="settings-section">
             <h3 style="margin-bottom: 1rem">API Configuration</h3>
 
             <div class="api-providers">
@@ -1261,6 +1243,7 @@
                 <a href="#" class="api-info-link" data-provider="METALS_DEV">
                   Provider Information
                 </a>
+                <div class="provider-history"></div>
                 <div class="api-key-row">
                   <label for="apiKey_METALS_DEV">Key:</label>
                   <input
@@ -1282,27 +1265,25 @@
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METALS_DEV"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METALS_DEV"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METALS_DEV"
-                        checked
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METALS_DEV"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1315,6 +1296,7 @@
                 <a href="#" class="api-info-link" data-provider="METALS_API">
                   Provider Information
                 </a>
+                <div class="provider-history"></div>
                 <div class="api-key-row">
                   <label for="apiKey_METALS_API">Key:</label>
                   <input
@@ -1336,26 +1318,25 @@
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METALS_API"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METALS_API"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METALS_API"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METALS_API"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1391,30 +1372,30 @@
                       <span class="status-dot"></span>
                       <span class="status-text">Disconnected</span>
                     </div>
+                    <div class="provider-history"></div>
                   </div>
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="METAL_PRICE_API"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="METAL_PRICE_API"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="METAL_PRICE_API"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="METAL_PRICE_API"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1446,6 +1427,7 @@
                     <option value="word">Word</option>
                   </select>
                 </div>
+                <div class="provider-history"></div>
                 <div class="api-key-row">
                   <label for="apiKey_CUSTOM">Key:</label>
                   <input
@@ -1467,26 +1449,25 @@
                   <div class="provider-actions">
                     <button
                       type="button"
-                      class="btn api-sync-btn"
+                      class="btn api-sync-btn success"
                       data-provider="CUSTOM"
                     >
                       Test & Sync
                     </button>
                     <button
                       type="button"
-                      class="btn api-clear-btn"
+                      class="btn api-clear-btn warning"
                       data-provider="CUSTOM"
                     >
                       Clear Key
                     </button>
-                    <label
-                      ><input
-                        type="radio"
-                        name="defaultProvider"
-                        value="CUSTOM"
-                      />
-                      Default</label
+                    <button
+                      type="button"
+                      class="btn provider-default-btn"
+                      data-provider="CUSTOM"
                     >
+                      Default
+                    </button>
                   </div>
                 </div>
               </div>
@@ -1504,8 +1485,39 @@
             </div>
 
             <div class="settings-actions">
-              <button type="button" class="btn" id="clearApiCacheBtn">
+              <button type="button" class="btn danger" id="clearApiCacheBtn">
                 Clear API Cache
+              </button>
+              <button type="button" class="btn" id="apiHistoryBtn">API History</button>
+            </div>
+          </div>
+
+          <div class="settings-section">
+            <h3>Appearance</h3>
+            <div class="theme-options">
+              <button
+                class="theme-btn"
+                data-theme="light"
+                title="Light"
+                aria-label="Light"
+              >
+                ☀️
+              </button>
+              <button
+                class="theme-btn"
+                data-theme="dark"
+                title="Dark"
+                aria-label="Dark"
+              >
+                🌙
+              </button>
+              <button
+                class="theme-btn"
+                data-theme="system"
+                title="System"
+                aria-label="System"
+              >
+                💻
               </button>
             </div>
           </div>
@@ -1530,6 +1542,22 @@
         <div id="apiInfoBody" class="api-info-body"></div>
         <div class="modal-footer">
           <button type="button" class="btn" id="apiInfoCloseBtn">Close</button>
+        </div>
+      </div>
+    </div>
+    <div class="modal" id="apiHistoryModal" style="display: none">
+      <div class="modal-content">
+        <h3>API Price History</h3>
+        <div class="api-history-body">
+          <table id="apiHistoryTable"></table>
+          <canvas id="apiHistoryChart"></canvas>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn" id="exportHistoryBtn">Export</button>
+          <button type="button" class="btn" id="clearHistoryBtn">
+            Clear History
+          </button>
+          <button type="button" class="btn" id="apiHistoryCloseBtn">Close</button>
         </div>
       </div>
     </div>

--- a/js/events.js
+++ b/js/events.js
@@ -194,19 +194,20 @@ const setupEventListeners = () => {
       );
     }
 
-    // Theme preference radios
-    const themeRadios = document.querySelectorAll(
-      'input[name="themePreference"]',
-    );
-    themeRadios.forEach((radio) => {
+    // Theme preference buttons
+    const themeButtons = document.querySelectorAll(".theme-btn");
+    themeButtons.forEach((btn) => {
       safeAttachListener(
-        radio,
-        "change",
+        btn,
+        "click",
         () => {
-          const value = radio.value;
+          const value = btn.dataset.theme;
           if (typeof setTheme === "function") {
             setTheme(value);
           }
+          themeButtons.forEach((b) =>
+            b.classList.toggle("active", b === btn)
+          );
         },
         "Theme preference change",
       );
@@ -1118,21 +1119,19 @@ const setupApiEvents = () => {
       );
     }
 
-    document
-      .querySelectorAll('input[name="defaultProvider"]')
-      .forEach((radio) => {
-        const provider = radio.value;
-        safeAttachListener(
-          radio,
-          "change",
-          () => {
-            if (radio.checked && typeof setDefaultProvider === "function") {
-              setDefaultProvider(provider);
-            }
-          },
-          "Default provider radio",
-        );
-      });
+    document.querySelectorAll(".provider-default-btn").forEach((btn) => {
+      const provider = btn.getAttribute("data-provider");
+      safeAttachListener(
+        btn,
+        "click",
+        () => {
+          if (typeof setDefaultProvider === "function") {
+            setDefaultProvider(provider);
+          }
+        },
+        "Default provider button",
+      );
+    });
 
     const clearCacheBtn = document.getElementById("clearApiCacheBtn");
     if (clearCacheBtn) {
@@ -1148,6 +1147,73 @@ const setupApiEvents = () => {
       );
     }
 
+    const historyBtn = document.getElementById("apiHistoryBtn");
+    if (historyBtn) {
+      safeAttachListener(
+        historyBtn,
+        "click",
+        () => {
+          if (typeof showApiHistoryModal === "function") {
+            showApiHistoryModal();
+          }
+        },
+        "API history button",
+      );
+    }
+
+    const historyModal = document.getElementById("apiHistoryModal");
+    const historyCloseBtn = document.getElementById("apiHistoryCloseBtn");
+    const clearHistoryBtn = document.getElementById("clearHistoryBtn");
+    const exportHistoryBtn = document.getElementById("exportHistoryBtn");
+    if (historyModal) {
+      safeAttachListener(
+        historyModal,
+        "click",
+        (e) => {
+          if (e.target === historyModal && typeof hideApiHistoryModal === "function") {
+            hideApiHistoryModal();
+          }
+        },
+        "API history modal background",
+      );
+    }
+    if (historyCloseBtn) {
+      safeAttachListener(
+        historyCloseBtn,
+        "click",
+        () => {
+          if (typeof hideApiHistoryModal === "function") {
+            hideApiHistoryModal();
+          }
+        },
+        "API history close button",
+      );
+    }
+    if (clearHistoryBtn) {
+      safeAttachListener(
+        clearHistoryBtn,
+        "click",
+        () => {
+          if (typeof clearApiHistory === "function") {
+            clearApiHistory();
+          }
+        },
+        "Clear API history button",
+      );
+    }
+    if (exportHistoryBtn) {
+      safeAttachListener(
+        exportHistoryBtn,
+        "click",
+        () => {
+          if (typeof exportApiHistory === "function") {
+            exportApiHistory();
+          }
+        },
+        "Export API history button",
+      );
+    }
+
     // ESC key to close modals
     safeAttachListener(
       document,
@@ -1156,6 +1222,7 @@ const setupApiEvents = () => {
         if (e.key === "Escape") {
           const settingsModal = document.getElementById("settingsModal");
           const infoModal = document.getElementById("apiInfoModal");
+          const historyModal = document.getElementById("apiHistoryModal");
           const editModal = document.getElementById("editModal");
           const detailsModal = document.getElementById("detailsModal");
 
@@ -1171,6 +1238,12 @@ const setupApiEvents = () => {
             typeof hideProviderInfo === "function"
           ) {
             hideProviderInfo();
+          } else if (
+            historyModal &&
+            historyModal.style.display === "flex" &&
+            typeof hideApiHistoryModal === "function"
+          ) {
+            hideApiHistoryModal();
           } else if (editModal && editModal.style.display === "flex") {
             editModal.style.display = "none";
             editingIndex = null;

--- a/js/init.js
+++ b/js/init.js
@@ -98,6 +98,7 @@ document.addEventListener("DOMContentLoaded", () => {
     debugLog("Phase 4: Initializing modal elements...");
     elements.settingsModal = safeGetElement("settingsModal");
     elements.apiInfoModal = safeGetElement("apiInfoModal");
+    elements.apiHistoryModal = safeGetElement("apiHistoryModal");
     elements.aboutModal = safeGetElement("aboutModal");
     elements.ackModal = safeGetElement("ackModal");
     elements.ackAcceptBtn = safeGetElement("ackAcceptBtn");

--- a/js/spot.js
+++ b/js/spot.js
@@ -53,7 +53,12 @@ const fetchSpotPrice = () => {
           spotPrices[metalConfig.key],
         );
       }
-      recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
+      const hasHistory = spotHistory.some(
+        (e) => e.metal === metalConfig.name,
+      );
+      if (!hasHistory) {
+        recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
+      }
     } else {
       // Use default price if no stored price
       const defaultPrice = metalConfig.defaultPrice;

--- a/js/state.js
+++ b/js/state.js
@@ -24,6 +24,7 @@ let columnFilter = { field: null, value: null };
 let chartInstances = {
   typeChart: null,
   locationChart: null,
+  apiHistoryChart: null,
 };
 
 /** @type {Object} Cached DOM elements for performance */
@@ -130,6 +131,7 @@ const elements = {
   settingsBtn: null,
   settingsModal: null,
   apiInfoModal: null,
+  apiHistoryModal: null,
 
   // Spot price action buttons
   spotSyncBtn: null,

--- a/js/theme.js
+++ b/js/theme.js
@@ -36,14 +36,10 @@ const setTheme = (theme) => {
  */
 const initTheme = () => {
   const savedTheme = localStorage.getItem(THEME_KEY);
-  const systemPrefersDark =
-    window.matchMedia &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches;
-
   if (savedTheme) {
     setTheme(savedTheme);
   } else {
-    setTheme(systemPrefersDark ? "dark" : "light");
+    setTheme("system");
   }
 };
 


### PR DESCRIPTION
## Summary
- show latest metal prices in single-row tables above API key inputs
- convert theme selection to icon buttons defaulting to system
- add API history export options and right-align modal controls

## Testing
- `node --check js/api.js`
- `node --check js/events.js`
- `node --check js/theme.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896b68274d8832e82ff9248ca692c37