### PR TITLE
Refine backup options and API modal layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -554,6 +554,7 @@ input[type="submit"] {
   display: flex;
   gap: 0.5rem;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .provider-footer {
@@ -562,6 +563,7 @@ input[type="submit"] {
   align-items: flex-start;
   margin-top: 0.5rem;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .provider-info {
@@ -892,7 +894,8 @@ input[type="submit"] {
 
 /* API Providers modal layout */
 #apiProvidersModal .modal-content {
-  max-width: 600px;
+  width: 90vw;
+  max-width: 800px;
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -2142,22 +2145,25 @@ input:disabled + .slider {
   text-align: center;
 }
 
-.boating-accident-section button {
-  padding: var(--spacing) var(--spacing-xl);
-  font-size: 1.125rem;
-  font-weight: 600;
-  background: var(--danger);
-  color: white;
-  border: none;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: var(--transition);
+.backup-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing);
+  margin-top: var(--spacing);
 }
 
-.boating-accident-section button:hover {
-  background: var(--danger-hover);
-  transform: scale(1.05);
-  box-shadow: var(--shadow-lg);
+.import-icon,
+.export-icon {
+  margin-left: 0.25rem;
+}
+
+.import-icon {
+  color: var(--success);
+}
+
+.export-icon {
+  color: var(--danger);
 }
 
 /* =============================================================================

--- a/index.html
+++ b/index.html
@@ -1252,15 +1252,15 @@
             <p class="settings-subtext">Import or export your data files.</p>
             <div class="import-section import-export-grid">
               <label class="btn" id="importCsvBtn">
-                Import CSV 📥
+                Import CSV <span class="import-icon">⬇️</span>
                 <input accept=".csv" hidden id="importCsvFile" type="file" />
               </label>
               <label class="btn" id="importJsonBtn">
-                Import JSON 📥
+                Import JSON <span class="import-icon">⬇️</span>
                 <input accept=".json" hidden id="importJsonFile" type="file" />
               </label>
               <label class="btn" id="importExcelBtn">
-                Import Excel 📥
+                Import Excel <span class="import-icon">⬇️</span>
                 <input
                   accept=".xlsx,.xls"
                   hidden
@@ -1268,6 +1268,7 @@
                   type="file"
                 />
               </label>
+              <button class="btn secondary" id="cloudSyncBtn">Cloud Sync ☁️</button>
             </div>
             <progress
               class="import-progress"
@@ -1277,20 +1278,34 @@
             ></progress>
             <div class="import-progress-text" id="importProgressText"></div>
             <div class="export-section import-export-grid">
-              <button class="btn" id="exportCsvBtn">Export CSV 📤</button>
-              <button class="btn" id="exportJsonBtn">Export JSON 📤</button>
-              <button class="btn" id="exportExcelBtn">Export Excel 📤</button>
-              <button class="btn" id="exportPdfBtn">Export PDF 📤</button>
-              <button class="btn" id="exportHtmlBtn">Export HTML 📤</button>
-              <button class="btn secondary" id="cloudSyncBtn">Cloud Sync ☁️</button>
+              <button class="btn" id="exportCsvBtn">
+                Export CSV <span class="export-icon">⬆️</span>
+              </button>
+              <button class="btn" id="exportJsonBtn">
+                Export JSON <span class="export-icon">⬆️</span>
+              </button>
+              <button class="btn" id="exportExcelBtn">
+                Export Excel <span class="export-icon">⬆️</span>
+              </button>
+              <button class="btn" id="exportPdfBtn">
+                Export PDF <span class="export-icon">⬆️</span>
+              </button>
+              <button class="btn" id="exportHtmlBtn">
+                Export HTML <span class="export-icon">⬆️</span>
+              </button>
             </div>
           </div>
 
           <div class="settings-section boating-accident-section">
             <p class="settings-subtext">Backup or restore all data.</p>
-            <button class="btn danger" id="boatingAccidentBtn">
-              🏴‍☠️ So you had a boating accident? 🏴‍☠️
-            </button>
+            <div class="backup-buttons">
+              <button class="btn success" id="backupAllBtn">
+                💎 All That Glitters 💎
+              </button>
+              <button class="btn danger" id="boatingAccidentBtn">
+                🏴‍☠️ Had a boating accident? 🏴‍☠️
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/js/events.js
+++ b/js/events.js
@@ -776,47 +776,25 @@ const setupEventListeners = () => {
       );
     }
 
-    // Backup All Button
+    // Backup/Restore Button
     if (elements.backupAllBtn) {
       safeAttachListener(
         elements.backupAllBtn,
         "click",
         async () => {
-          if (typeof createBackupZip === "function") {
-            await createBackupZip();
+          if (
+            confirm(
+              "Create a complete backup? Click Cancel to restore from a backup file.",
+            )
+          ) {
+            if (typeof createBackupZip === "function") {
+              await createBackupZip();
+            } else {
+              alert("Creating backup using export functions...");
+              exportCsv();
+              exportJson();
+            }
           } else {
-            alert("Creating backup using export functions...");
-            exportCsv();
-            exportJson();
-          }
-        },
-        "Backup all button",
-      );
-    }
-
-    // BOATING ACCIDENT BUTTON
-    const updateBoatingAccidentButton = () => {
-      const btn = elements.boatingAccidentBtn;
-      if (!btn) return;
-      const hasData = !!localStorage.getItem(LS_KEY);
-      if (hasData) {
-        btn.classList.add("danger");
-        btn.classList.remove("success");
-        btn.textContent = "🏴‍☠️ So you had a boating accident? 🏴‍☠️";
-      } else {
-        btn.classList.remove("danger");
-        btn.classList.add("success");
-        btn.textContent = "💎 All that glitters is not gold 💎";
-      }
-    };
-    if (elements.boatingAccidentBtn) {
-      updateBoatingAccidentButton();
-      safeAttachListener(
-        elements.boatingAccidentBtn,
-        "click",
-        async function () {
-          const hasData = !!localStorage.getItem(LS_KEY);
-          if (!hasData) {
             const input = document.createElement("input");
             input.type = "file";
             input.accept = ".zip";
@@ -825,49 +803,46 @@ const setupEventListeners = () => {
                 e.target.files.length > 0 &&
                 typeof restoreBackupZip === "function"
               ) {
-                restoreBackupZip(e.target.files[0]).then(() => {
-                  updateBoatingAccidentButton();
-                });
+                restoreBackupZip(e.target.files[0]);
               }
             });
             input.click();
-            return;
           }
+        },
+        "Backup all button",
+      );
+    }
 
+    // Boating Accident Button
+    if (elements.boatingAccidentBtn) {
+      safeAttachListener(
+        elements.boatingAccidentBtn,
+        "click",
+        function () {
           if (
             confirm(
-              "This will export all data and then erase it. Continue?",
+              "Did you really lose it all in a boating accident? This will wipe all local data.",
             )
           ) {
-            if (typeof createBackupZip === "function") {
-              await createBackupZip();
-            }
-            if (
-              confirm(
-                "All local data will be removed after export. Proceed?",
-              )
-            ) {
-              localStorage.removeItem(LS_KEY);
-              localStorage.removeItem(SPOT_HISTORY_KEY);
-              localStorage.removeItem(API_KEY_STORAGE_KEY);
-              localStorage.removeItem(API_CACHE_KEY);
-              Object.values(METALS).forEach((metalConfig) => {
-                localStorage.removeItem(metalConfig.localStorageKey);
-              });
-              sessionStorage.clear();
+            localStorage.removeItem(LS_KEY);
+            localStorage.removeItem(SPOT_HISTORY_KEY);
+            localStorage.removeItem(API_KEY_STORAGE_KEY);
+            localStorage.removeItem(API_CACHE_KEY);
+            Object.values(METALS).forEach((metalConfig) => {
+              localStorage.removeItem(metalConfig.localStorageKey);
+            });
+            sessionStorage.clear();
 
-              loadInventory();
-              renderTable();
-              loadSpotHistory();
-              fetchSpotPrice();
+            loadInventory();
+            renderTable();
+            loadSpotHistory();
+            fetchSpotPrice();
 
-              apiConfig = { provider: "", keys: {} };
-              apiCache = null;
-              updateSyncButtonStates();
+            apiConfig = { provider: "", keys: {} };
+            apiCache = null;
+            updateSyncButtonStates();
 
-              alert("All data has been erased.");
-              updateBoatingAccidentButton();
-            }
+            alert("All data has been erased. Hope your scuba gear is ready!");
           }
         },
         "Boating accident button",


### PR DESCRIPTION
## Summary
- Widen API providers modal and allow action buttons to wrap for better layout
- Split backup and data-wipe actions into "All That Glitters" backup/restore and humorous Boating Accident wipe button
- Group import/export buttons with arrow icons, move Cloud Sync into imports, and style new icon colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896dd3ba0dc832e8d61361b518f86aa