### PR TITLE
Expand settings modal and refine settings UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -553,17 +553,19 @@ input[type="submit"] {
 
 .provider-footer {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   margin-top: 0.5rem;
   gap: 1rem;
-  flex-wrap: wrap;
 }
 
 .provider-info {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  align-items: center;
+  text-align: center;
 }
 
 .provider-history {
@@ -593,15 +595,13 @@ input[type="submit"] {
   align-items: center;
   flex-wrap: wrap;
   gap: var(--spacing-sm);
-}
-
-.provider-default-btn {
-  margin-right: auto;
+  justify-content: center;
 }
 
 .provider-actions-right {
   display: flex;
   gap: var(--spacing-sm);
+  justify-content: center;
 }
 
 .provider-checkbox-row label {
@@ -724,7 +724,28 @@ input[type="submit"] {
   display: flex;
   gap: 1rem;
   justify-content: center;
+  flex-wrap: nowrap;
+}
+
+.api-status-summary {
+  margin-top: 0.5rem;
+  display: flex;
   flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  font-size: 0.875rem;
+}
+
+.api-status-summary .status-item.connected {
+  color: var(--success);
+}
+
+.api-status-summary .status-item.disconnected {
+  color: var(--text-secondary);
+}
+
+.api-status-summary .status-item.error {
+  color: var(--danger);
 }
 
 .settings-subtext {
@@ -853,8 +874,8 @@ input[type="submit"] {
 
 /* Settings modal layout */
 #settingsModal .modal-content {
-  max-width: 600px;
-  max-height: 80vh;
+  max-width: 750px;
+  max-height: 90vh;
   display: flex;
   flex-direction: column;
   padding: 0;
@@ -2056,13 +2077,14 @@ td input:checked + .slider:before {
 
 .import-export-grid .btn,
 .import-export-grid label.btn {
-  height: auto;
-  min-height: 2.75rem;
+  height: 2.75rem;
   padding: var(--spacing-sm);
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
+  margin: 0;
+  line-height: 1;
 }
 
 .import-export-grid label.btn {
@@ -2184,7 +2206,7 @@ input:disabled + .slider {
 }
 
 .export-icon {
-  color: var(--danger);
+  color: var(--info);
 }
 
 /* =============================================================================

--- a/index.html
+++ b/index.html
@@ -1219,6 +1219,8 @@
               </select>
             </div>
 
+            <div class="api-status-summary" id="apiStatusSummary"></div>
+
             <div class="settings-actions">
               <button type="button" class="btn" id="providersBtn">
                 Providers 🖥️
@@ -1255,15 +1257,15 @@
               <div class="import-block">
                 <div class="import-export-grid">
                   <label class="btn" id="importCsvBtn">
-                    Import CSV <span class="import-icon">📤</span>
+                    Import CSV <span class="import-icon">⬇️</span>
                     <input accept=".csv" hidden id="importCsvFile" type="file" />
                   </label>
                   <label class="btn" id="importJsonBtn">
-                    Import JSON <span class="import-icon">📤</span>
+                    Import JSON <span class="import-icon">⬇️</span>
                     <input accept=".json" hidden id="importJsonFile" type="file" />
                   </label>
                   <label class="btn" id="importExcelBtn">
-                    Import Excel <span class="import-icon">📤</span>
+                    Import Excel <span class="import-icon">⬇️</span>
                     <input
                       accept=".xlsx,.xls"
                       hidden
@@ -1284,16 +1286,16 @@
               <div class="export-block">
                 <div class="import-export-grid">
                   <button class="btn" id="exportCsvBtn">
-                    Export CSV <span class="export-icon">📥</span>
+                    Export CSV <span class="export-icon">⬆️</span>
                   </button>
                   <button class="btn" id="exportJsonBtn">
-                    Export JSON <span class="export-icon">📥</span>
+                    Export JSON <span class="export-icon">⬆️</span>
                   </button>
                   <button class="btn" id="exportExcelBtn">
-                    Export Excel <span class="export-icon">📥</span>
+                    Export Excel <span class="export-icon">⬆️</span>
                   </button>
                   <button class="btn" id="exportPdfBtn">
-                    Export PDF <span class="export-icon">📥</span>
+                    Export PDF <span class="export-icon">⬆️</span>
                   </button>
                 </div>
               </div>
@@ -1304,7 +1306,7 @@
             <p class="settings-subtext">Clear all data from the app.</p>
             <div class="backup-buttons">
               <button class="btn danger" id="boatingAccidentBtn">
-                🏴‍☠️ Have you had a boating accident? 🏴‍☠️
+                🏴‍☠️ So, you've been in a boating accident? 🏴‍☠️
               </button>
             </div>
           </div>

--- a/js/api.js
+++ b/js/api.js
@@ -9,6 +9,25 @@ const providerStatuses = {
   CUSTOM: "disconnected",
 };
 
+const renderApiStatusSummary = () => {
+  const container = document.getElementById("apiStatusSummary");
+  if (!container) return;
+  const html = Object.keys(API_PROVIDERS)
+    .map((prov) => {
+      const status = providerStatuses[prov] || "disconnected";
+      const name = API_PROVIDERS[prov].name;
+      const statusText =
+        status === "connected"
+          ? "Connected"
+          : status === "error"
+            ? "Error"
+            : "Disconnected";
+      return `<span class="status-item ${status}">${name}: ${statusText}</span>`;
+    })
+    .join("");
+  container.innerHTML = html;
+};
+
 // API history table state
 let apiHistoryEntries = [];
 let apiHistoryPage = 1;
@@ -176,6 +195,7 @@ const getCacheDurationMs = () => {
  */
 const setProviderStatus = (provider, status) => {
   providerStatuses[provider] = status;
+  renderApiStatusSummary();
   const block = document.querySelector(
     `.api-provider[data-provider="${provider}"] .provider-status`,
   );
@@ -1080,6 +1100,7 @@ const showSettingsModal = () => {
     if (input) input.value = currentConfig.keys?.[prov] || "";
     setProviderStatus(prov, providerStatuses[prov] || "disconnected");
   });
+  renderApiStatusSummary();
 
   const baseInput = document.getElementById("apiBase_CUSTOM");
   if (baseInput) baseInput.value = currentConfig.customConfig?.baseUrl || "";


### PR DESCRIPTION
## Summary
- Widen settings modal and keep API action buttons in one row
- Add color-coded API sync status summary and update import/export visuals
- Center provider tables and actions in API Providers modal and refine boating accident phrasing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f109a0ec832e862f3629142bc51d