### PR TITLE
style: rearrange metal labels in API provider modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -606,6 +606,13 @@ input[type="submit"] {
 
 .provider-checkbox-row label {
   font-size: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.provider-checkbox-row .provider-metal-name {
+  margin-top: 0.25rem;
 }
 
 .api-usage {

--- a/js/api.js
+++ b/js/api.js
@@ -233,7 +233,8 @@ const updateProviderHistoryTables = () => {
     const metals = ["Silver", "Gold", "Platinum", "Palladium"];
     const selections = config.metals?.[prov] || {};
     let table = '<table class="provider-table"><tr class="provider-price-row"><th class="provider-label">Last Price:</th>';
-    let checkboxRow = '<tr class="provider-checkbox-row"><th class="provider-label">Enable:</th>';
+    let checkboxRow =
+      '<tr class="provider-checkbox-row"><th class="provider-label">Enable:</th>';
     metals.forEach((metal) => {
       const entries = history.filter(
         (e) => e.provider === providerName && e.metal === metal,
@@ -244,7 +245,7 @@ const updateProviderHistoryTables = () => {
       const key = metal.toLowerCase();
       const checked = selections[key] !== false ? "checked" : "";
       table += `<td>${last}</td>`;
-      checkboxRow += `<td><label><input type="checkbox" class="provider-metal" data-provider="${prov}" data-metal="${key}" ${checked}/> ${metal}</label></td>`;
+      checkboxRow += `<td><label><input type="checkbox" class="provider-metal" data-provider="${prov}" data-metal="${key}" ${checked}/><span class="provider-metal-name">${metal}</span></label></td>`;
     });
     table += '</tr>';
     checkboxRow += '</tr></table>';


### PR DESCRIPTION
## Summary
- Display metal names beneath enable checkboxes in API providers modal
- Add flex styling to stack checkbox labels vertically

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896f35408a0832ea9da89b89acb755d