### PR TITLE
chore: rebrand to StackTrackr and prepare 3.2.02rc RC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# Precious Metals Inventory Tool v3.2.01
+# StackTrackr v3.2.02rc
 
-The Precious Metals Inventory Tool is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
+StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
+- **v3.2.02rc - Feature Complete Release Candidate**: Rebranded to StackTrackr and prepared for final release
 - **v3.2.01 - Cloud Sync Modal Fix**: Coming soon modal now matches themed styling with internal close button
 - **v3.2.0 - Settings & History Polish**: Appearance section moved up, sync confirmation dialog, and redesigned API history modal with clear filter
 - **v3.1.13 - Cloud Sync & API Quotas**: CSV import fix, Cloud Sync placeholder, and API usage tracking with monthly reset
@@ -13,8 +14,9 @@ The Precious Metals Inventory Tool is a comprehensive client-side web applicatio
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
 
-## 🆕 What's New in v3.2.01
-- Cloud Sync modal now uses standard theming with internal close button
+## 🆕 What's New in v3.2.02rc
+- Application renamed to **StackTrackr**
+- Marked as **feature complete** for the 3.2.x series
 
 ## 🆕 What's New in v3.2.0
 - Appearance settings now appear before API configuration for quicker access
@@ -210,9 +212,9 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.2.01
-**Last Updated**: August 8, 2025
-**Status**: Feature complete with enhanced documentation workflow
+**Current Version**: 3.2.02rc
+**Last Updated**: August 9, 2025
+**Status**: Feature complete release candidate
 
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Precious Metals Inventory Tool — Changelog
+# StackTrackr — Changelog
 
 ## 🚀 Roadmap (Future Versions)
 
@@ -7,6 +7,10 @@
 ---
 
 ## 📋 Version History
+
+### Version 3.2.02rc – Feature Complete Release Candidate (2025-08-09)
+- Rebranded application to StackTrackr
+- Marked as feature complete release candidate for the 3.2.x series
 
 ### Version 3.2.01 – Cloud Sync Modal Fix (2025-08-08)
 - Cloud Sync placeholder modal now uses standard themed header with internal close button

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - Precious Metals Inventory Tool v3.2.01
+# Multi-Agent Development Workflow - StackTrackr v3.2.02rc
 
 ## 🎯 Project Overview
 
-You are contributing to the **Precious Metals Inventory Tool v3.2.01**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.2.02rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.2.01 (stable)
+**Current Status**: v3.2.02rc (feature-complete release candidate)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -287,6 +287,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.01 vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.02rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Precious Metals Inventory Tool - Development Roadmap
+# StackTrackr - Development Roadmap
 
 ## 🎯 Milestone: Version 3.5.0
 **Target: Complete UI reorganization, enhanced data management, and multi-currency support**
@@ -250,4 +250,4 @@
 
 ---
 
-*This roadmap represents a comprehensive enhancement to the Precious Metals Inventory Tool, transforming it from a solid inventory management system into a professional-grade application with advanced data management, security, and international support capabilities.*
+*This roadmap represents a comprehensive enhancement to the StackTrackr, transforming it from a solid inventory management system into a professional-grade application with advanced data management, security, and international support capabilities.*

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
-# Project Status - Precious Metals Inventory Tool
+# Project Status - StackTrackr
 
-## 🎯 Current State: **FEATURE COMPLETE v3.2.01** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **FEATURE COMPLETE v3.2.02rc** ✅ MAINTAINED & OPTIMIZED
 
-**Precious Metals Inventory Tool v3.2.01** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.2.02rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.1.x Series)
 
+- **v3.2.02rc - Feature Complete Release Candidate**: Application rebranded to StackTrackr and prepared for final release
 - **v3.2.01 - Cloud Sync Modal Fix**: Coming soon modal now follows themed styling with internal close button
 - **v3.2.0 - Settings & History Polish**: Appearance section moved up, sync confirmation dialog, and API history modal redesign
 - **v3.1.13 - Cloud Sync & API Quotas**: Cloud Sync placeholder modal, API usage tracking with quotas and monthly reset, Sync All provider button, reorganized file tools, and interface polish
@@ -102,7 +103,7 @@ All data is stored locally in the browser using localStorage with:
 - ✅ Modern, responsive user interface
 - ✅ Complete documentation and error handling
 
-## 📚 Documentation Status (Updated: August 8, 2025)
+## 📚 Documentation Status (Updated: August 9, 2025)
 
 **All documentation files are current and synchronized:**
 - ✅ **STATUS.md** - Updated with 3.1.x series changes and current state
@@ -115,9 +116,9 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.2.01 (managed in `js/constants.js`)
+1. **Current Version**: 3.2.02rc (managed in `js/constants.js`)
 2. **Last Change**: Cloud Sync modal adopts standard theme with internal close button
-3. **Last Documentation Update**: August 8, 2025 - All docs synchronized
+3. **Last Documentation Update**: August 9, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase
 6. **Data Structure**: Includes all fields (metal, name, qty, type, weight, price, date, purchaseLocation, storageLocation, **notes**, spotPriceAtPurchase, premiumPerOz, totalPremium, isCollectable)
@@ -130,7 +131,7 @@ If continuing development in a new chat session:
 ## 📁 Project Structure
 
 ```
-PreciousMetalInventoryTool/
+StackTrackr/
 ├── js/                     # Modular JavaScript (cleaned structure)
 │   ├── constants.js        # Version 3.1.12 + metal configs
 │   ├── state.js           # App state + DOM caching
@@ -154,6 +155,6 @@ PreciousMetalInventoryTool/
 
 ---
 
-**Last Updated**: August 8, 2025  
-**Status**: ✅ COMPLETE - Maintained and optimized for production use  
+**Last Updated**: August 9, 2025
+**Status**: ✅ COMPLETE - Release candidate ready for production use
 **Documentation**: ✅ ALL FILES SYNCHRONIZED AND CURRENT

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -2,12 +2,12 @@
 
 ## Overview 
 
-The Precious Metals Inventory Tool now uses a dynamic version management system that automatically updates version numbers throughout the application from a single source of truth.
+The StackTrackr now uses a dynamic version management system that automatically updates version numbers throughout the application from a single source of truth.
 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `/app/js/constants.js` as `APP_VERSION = '3.0.5'`
+- Version is defined once in `/app/js/constants.js` as `APP_VERSION = '3.2.02rc'`
 - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -28,14 +28,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In /app/js/constants.js
-   const APP_VERSION = '3.0.5';  // Change this line only
+   const APP_VERSION = '3.2.02rc';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Root page title: "Lonnie's Precious Metals Tool v3.1.0"
-   - Root page heading: "Lonnie's Precious Metals Tool v3.1.0"
-   - App page title: "Precious Metals Inventory Tool v3.1.0"
-   - App header: "Precious Metals Inventory Tool v3.1.0"
+   - Root page title: "StackTrackr v3.1.0"
+   - Root page heading: "StackTrackr v3.1.0"
+   - App page title: "StackTrackr v3.1.0"
+   - App header: "StackTrackr v3.1.0"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -45,7 +45,7 @@ To release a new version:
 ```javascript
 // Loads app/js/constants.js and utils.js
 // Updates title and heading via DOM manipulation
-document.title = `Lonnie's Precious Metals Tool ${getVersionString()}`;
+document.title = `StackTrackr ${getVersionString()}`;
 ```
 
 ### Main App (app/app/index.html)
@@ -77,15 +77,15 @@ Use semantic versioning: `MAJOR.MINOR.PATCH`
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.0.5"
+const version = APP_VERSION; // "3.2.02rc"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.0.5"
-const customVersion = getVersionString('version '); // "version 3.0.5"
+const versionString = getVersionString(); // "v3.2.02rc"
+const customVersion = getVersionString('version '); // "version 3.2.02rc"
 
 // Get full app title
-const title = getAppTitle(); // "Precious Metals Inventory Tool v3.0.5"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.0.5"
+const title = getAppTitle(); // "StackTrackr v3.2.02rc"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.02rc"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/archive/LLM.md
+++ b/docs/archive/LLM.md
@@ -1,4 +1,4 @@
-# LLM Development Guide — Precious Metals Inventory Tool
+# LLM Development Guide — StackTrackr
 
 > **CRITICAL**: Keep all documentation in sync with code updates.  
 >  
@@ -17,7 +17,7 @@
 
 ## 1. Purpose
 
-Provide AI assistants (LLMs) a concise, up-to-date overview of the **Precious Metals Inventory Tool v3.2.01** to guide development, documentation, and QA tasks.
+Provide AI assistants (LLMs) a concise, up-to-date overview of the **StackTrackr v3.2.02rc** to guide development, documentation, and QA tasks.
 
 ## 2. Project Snapshot
 
@@ -30,12 +30,12 @@ Provide AI assistants (LLMs) a concise, up-to-date overview of the **Precious Me
   - **Comprehensive backup ZIP system** with all data formats and restoration guides
   - Responsive & accessible UI (mobile-first, ARIA, keyboard support)  
   - Modular JS architecture (constants, state, events, utils, inventory)  
-- **Version**: 3.2.01 (Cloud Sync modal theming fix)
-- **Last Updated**: August 8, 2025  
+- **Version**: 3.2.02rc (feature complete release candidate)
+- **Last Updated**: August 9, 2025
 
 ## 3. Project Structure
 
-PreciousMetalInventoryTool/
+StackTrackr/
 ├── app/
 │   ├── index.html
 │   ├── css/styles.css

--- a/docs/notes/BUTTON_FIX_README.md
+++ b/docs/notes/BUTTON_FIX_README.md
@@ -1,4 +1,4 @@
-# Precious Metals Inventory Tool - Button Functionality Fix
+# StackTrackr - Button Functionality Fix
 
 ## Summary
 Fixed the non-functioning "Add" and "Reset" buttons for spot price management. All spot price buttons now work correctly across all four supported metals (Silver, Gold, Platinum, Palladium).

--- a/docs/notes/FILE_PROTOCOL_FIXES.md
+++ b/docs/notes/FILE_PROTOCOL_FIXES.md
@@ -1,6 +1,6 @@
 # File:// Protocol Compatibility Fixes
 
-This document explains the enhancements made to ensure the Precious Metals Inventory Tool works reliably when loaded directly from the file system (file:// protocol) without requiring a local server.
+This document explains the enhancements made to ensure the StackTrackr works reliably when loaded directly from the file system (file:// protocol) without requiring a local server.
 
 ## Problem
 

--- a/docs/notes/documentation-consolidation.md
+++ b/docs/notes/documentation-consolidation.md
@@ -15,7 +15,7 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 ## Replacement
 `docs/MULTI_AGENT_WORKFLOW.md` provides:
 - ✅ **Complete project context** - Everything from LLM.md plus more
-- ✅ **Current v3.2.01 focus** - Up-to-date technical information
+- ✅ **Current v3.2.02rc focus** - Up-to-date technical information
 - ✅ **Actionable workflow guidance** - Specific step-by-step processes
 - ✅ **Quality standards** - Testing and validation protocols
 - ✅ **Coordination system** - Multi-agent conflict prevention

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
-  Precious Metals Inventory Tool - Main Application Interface
+  StackTrackr - Main Application Interface
   
   A comprehensive client-side web application for tracking precious metal investments
   including silver, gold, platinum, and palladium. Features include spot price management,
@@ -29,7 +29,7 @@
     />
 
     <!-- Title is dynamically updated by init.js using APP_VERSION constant -->
-    <title>Precious Metals Inventory Tool</title>
+    <title>StackTrackr</title>
     <!-- FILE PROTOCOL COMPATIBILITY - MUST LOAD FIRST -->
     <script src="./js/file-protocol-fix.js"></script>
 
@@ -66,7 +66,7 @@
   <body>
     <!-- Application Header -->
     <div class="app-header">
-      <h1>Precious Metals Inventory Tool</h1>
+      <h1>StackTrackr</h1>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button
           class="btn"
@@ -1036,7 +1036,7 @@
       <div class="modal-content about-modal-content">
         <div class="modal-header about-modal-header">
           <h1 class="about-title">
-            Precious Metals Inventory Tool <span id="ackVersion"></span>
+            StackTrackr <span id="ackVersion"></span>
           </h1>
           <button aria-label="Close modal" class="modal-close" id="ackCloseBtn">
             ×
@@ -1117,7 +1117,7 @@
         </div>
         <div class="modal-body about-modal-body">
           <h2 class="about-title" id="aboutTitle">
-            Precious Metals Inventory Tool <span id="aboutVersion"></span>
+            StackTrackr <span id="aboutVersion"></span>
           </h2>
           <!-- Key Features -->
           <div class="about-features">

--- a/js/api.js
+++ b/js/api.js
@@ -1422,7 +1422,7 @@ const downloadCompleteBackup = async () => {
 
     // 4. Create API documentation and restoration guide
     const backupData = createBackupData();
-    const apiInfo = `# Precious Metals Tool - Complete Backup
+    const apiInfo = `# StackTrackr - Complete Backup
 
 Generated: ${new Date().toLocaleString()}
 Application Version: ${APP_VERSION}
@@ -1474,7 +1474,7 @@ ${
 2. Reconfigure API settings if needed (keys not backed up for security)
 3. Use **complete-backup-${timestamp}.json** for full data restoration if needed
 
-*This backup was created by Precious Metals Inventory Tool v${APP_VERSION}*
+*This backup was created by StackTrackr v${APP_VERSION}*
 `;
 
     downloadFile(`backup-info-${timestamp}.md`, apiInfo, "text/markdown");

--- a/js/constants.js
+++ b/js/constants.js
@@ -93,10 +93,10 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = "3.2.01";
+const APP_VERSION = "3.2.02rc";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
-const BRANDING_TITLE = "";
+const BRANDING_TITLE = "StackTrackr";
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
 const LS_KEY = "metalInventory";

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -265,7 +265,7 @@ const generateBackupHtml = (sortedInventory, timeFormatted) => {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Precious Metals Inventory Backup</title>
+  <title>StackTrackr Backup</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 20px; }
     h1 { color: #2563eb; }
@@ -276,7 +276,7 @@ const generateBackupHtml = (sortedInventory, timeFormatted) => {
   </style>
 </head>
 <body>
-  <h1>Precious Metals Inventory Backup</h1>
+  <h1>StackTrackr Backup</h1>
   <div class="backup-info">
     <strong>Backup Created:</strong> ${timeFormatted}<br>
     <strong>Application Version:</strong> ${APP_VERSION}<br>
@@ -388,7 +388,7 @@ RESTORATION INSTRUCTIONS:
 SUPPORT:
 --------
 
-For questions about this backup or the Precious Metals Inventory Tool:
+For questions about this backup or the StackTrackr application:
 - Check the application documentation
 - Verify file integrity before restoration
 - Test imports with sample data first
@@ -1442,7 +1442,7 @@ const exportPdf = () => {
 
   // Add title
   doc.setFontSize(16);
-  doc.text("Precious Metals Inventory", 14, 15);
+  doc.text("StackTrackr", 14, 15);
 
   // Add date
   doc.setFontSize(10);

--- a/js/utils.js
+++ b/js/utils.js
@@ -21,10 +21,10 @@ const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
 /**
  * Returns full application title with version
  *
- * @param {string} [baseTitle='Precious Metals Inventory Tool'] - Base application title
+ * @param {string} [baseTitle='StackTrackr'] - Base application title
  * @returns {string} Full title with version
  */
-const getAppTitle = (baseTitle = "Precious Metals Inventory Tool") =>
+const getAppTitle = (baseTitle = "StackTrackr") =>
   BRANDING_TITLE && BRANDING_TITLE.trim()
     ? BRANDING_TITLE
     : `${baseTitle} ${getVersionString()}`;

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
-# Precious Metals Inventory Tool - Project Structure
+# StackTrackr - Project Structure
 
-## Current Structure (Version 3.2.01)
+## Current Structure (Version 3.2.02rc)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- rename application branding to StackTrackr
- bump version to 3.2.02rc and mark release as feature complete
- update docs and UI text for new branding

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896fcd11d08832e90a1247f3f8c7d1b