### PR TITLE
Add cache flush confirmation and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# StackTrackr v3.2.02rc
+# StackTrackr v3.2.03rc
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
+- **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Rebranded to StackTrackr and prepared for final release
 - **v3.2.01 - Cloud Sync Modal Fix**: Coming soon modal now matches themed styling with internal close button
 - **v3.2.0 - Settings & History Polish**: Appearance section moved up, sync confirmation dialog, and redesigned API history modal with clear filter
@@ -13,6 +14,9 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.2.03rc
+- Added confirmation prompt before flushing API cache and history
 
 ## 🆕 What's New in v3.2.02rc
 - Application renamed to **StackTrackr**
@@ -212,7 +216,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.2.02rc
+**Current Version**: 3.2.03rc
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 📋 Version History
 
+### Version 3.2.03rc – Cache Flush Confirmation (2025-08-09)
+- Added warning prompt before clearing API cache and history
+
 ### Version 3.2.02rc – Feature Complete Release Candidate (2025-08-09)
 - Rebranded application to StackTrackr
 - Marked as feature complete release candidate for the 3.2.x series

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - StackTrackr v3.2.02rc
+# Multi-Agent Development Workflow - StackTrackr v3.2.03rc
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.2.02rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.2.03rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.2.02rc (feature-complete release candidate)
+**Current Status**: v3.2.03rc (feature-complete release candidate)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -287,6 +287,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.02rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.03rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **FEATURE COMPLETE v3.2.02rc** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **FEATURE COMPLETE v3.2.03rc** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.2.02rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.2.03rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.1.x Series)
 
+- **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Application rebranded to StackTrackr and prepared for final release
 - **v3.2.01 - Cloud Sync Modal Fix**: Coming soon modal now follows themed styling with internal close button
 - **v3.2.0 - Settings & History Polish**: Appearance section moved up, sync confirmation dialog, and API history modal redesign
@@ -116,8 +117,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.2.02rc (managed in `js/constants.js`)
-2. **Last Change**: Cloud Sync modal adopts standard theme with internal close button
+1. **Current Version**: 3.2.03rc (managed in `js/constants.js`)
+2. **Last Change**: Added confirmation before flushing API cache and history
 3. **Last Documentation Update**: August 9, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,7 +7,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `/app/js/constants.js` as `APP_VERSION = '3.2.02rc'`
+- Version is defined once in `/app/js/constants.js` as `APP_VERSION = '3.2.03rc'`
 - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -28,7 +28,7 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In /app/js/constants.js
-   const APP_VERSION = '3.2.02rc';  // Change this line only
+   const APP_VERSION = '3.2.03rc';  // Change this line only
    ```
 
 2. **All these will automatically update:**
@@ -77,15 +77,15 @@ Use semantic versioning: `MAJOR.MINOR.PATCH`
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.2.02rc"
+const version = APP_VERSION; // "3.2.03rc"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.2.02rc"
-const customVersion = getVersionString('version '); // "version 3.2.02rc"
+const versionString = getVersionString(); // "v3.2.03rc"
+const customVersion = getVersionString('version '); // "version 3.2.03rc"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.2.02rc"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.02rc"
+const title = getAppTitle(); // "StackTrackr v3.2.03rc"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.03rc"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/archive/LLM.md
+++ b/docs/archive/LLM.md
@@ -17,7 +17,7 @@
 
 ## 1. Purpose
 
-Provide AI assistants (LLMs) a concise, up-to-date overview of the **StackTrackr v3.2.02rc** to guide development, documentation, and QA tasks.
+Provide AI assistants (LLMs) a concise, up-to-date overview of the **StackTrackr v3.2.03rc** to guide development, documentation, and QA tasks.
 
 ## 2. Project Snapshot
 
@@ -30,7 +30,7 @@ Provide AI assistants (LLMs) a concise, up-to-date overview of the **StackTrackr
   - **Comprehensive backup ZIP system** with all data formats and restoration guides
   - Responsive & accessible UI (mobile-first, ARIA, keyboard support)  
   - Modular JS architecture (constants, state, events, utils, inventory)  
-- **Version**: 3.2.02rc (feature complete release candidate)
+- **Version**: 3.2.03rc (feature complete release candidate)
 - **Last Updated**: August 9, 2025
 
 ## 3. Project Structure

--- a/docs/notes/documentation-consolidation.md
+++ b/docs/notes/documentation-consolidation.md
@@ -15,7 +15,7 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 ## Replacement
 `docs/MULTI_AGENT_WORKFLOW.md` provides:
 - ✅ **Complete project context** - Everything from LLM.md plus more
-- ✅ **Current v3.2.02rc focus** - Up-to-date technical information
+- ✅ **Current v3.2.03rc focus** - Up-to-date technical information
 - ✅ **Actionable workflow guidance** - Specific step-by-step processes
 - ✅ **Quality standards** - Testing and validation protocols
 - ✅ **Coordination system** - Multi-agent conflict prevention

--- a/js/constants.js
+++ b/js/constants.js
@@ -93,7 +93,7 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = "3.2.02rc";
+const APP_VERSION = "3.2.03rc";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/js/events.js
+++ b/js/events.js
@@ -1202,7 +1202,11 @@ const setupApiEvents = () => {
         "click",
         () => {
           if (typeof clearApiCache === "function") {
-            clearApiCache();
+            const warnMessage =
+              "This will delete the API cache and history. Click OK to continue or Cancel to keep it.";
+            if (confirm(warnMessage)) {
+              clearApiCache();
+            }
           }
         },
         "Flush cache button",

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.2.02rc)
+## Current Structure (Version 3.2.03rc)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- warn users before flushing API cache/history
- bump version to 3.2.03rc and update docs

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6896ff430980832e9da14862ef58b5b2