### PR TITLE
Fix disclaimer splash checkbox alignment

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1514,12 +1514,16 @@ td input:checked + .slider:before {
 .ack-options {
   margin-top: 1rem;
   color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .ack-options label {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  font-size: 0.875rem;
 }
 
 .about-modal-body::-webkit-scrollbar {

--- a/index.html
+++ b/index.html
@@ -1090,16 +1090,16 @@
               </p>
             </div>
           </div>
-          <div class="ack-options">
-            <label>
-              <input type="checkbox" id="ackDontShow" />
-              Do not show this again
-            </label>
-          </div>
           <div class="alert-actions">
             <button class="btn btn-primary about-accept-btn" id="ackAcceptBtn">
               ✅ I Understand - Continue to Application
             </button>
+          </div>
+          <div class="ack-options">
+            <label for="ackDontShow">
+              <input type="checkbox" id="ackDontShow" />
+              <span>Do not show this again</span>
+            </label>
           </div>
           <div class="acceptance-text">
             By continuing, you acknowledge that you understand this tool stores


### PR DESCRIPTION
## Summary
- Place "Do not show this again" checkbox under the disclaimer accept button
- Center opt-out label and use smaller font for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689723118b24832e86fa75dcaac9030e