### PR TITLE
Simplify splash acknowledgement and add subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
-- **v3.2.05rc - Splash Opt-Out**: Disclaimer modal can be hidden permanently
+- **v3.2.05rc - Splash Opt-Out**: Disclaimer modal now remembers acceptance automatically
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Rebranded to StackTrackr and prepared for final release
@@ -18,7 +18,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
 
 ## 🆕 What's New in v3.2.05rc
-- Added "Do not show this again" option to the disclaimer splash
+- Disclaimer splash hides permanently after you click "I Understand"
 
 ## 🆕 What's New in v3.2.04rc
 - Negative prices in imported files now default to $0 instead of causing errors

--- a/css/styles.css
+++ b/css/styles.css
@@ -171,9 +171,26 @@ label {
   box-shadow: var(--shadow-sm);
 }
 
-.app-header h1 {
+.app-title {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-title h1 {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-weight: 600;
+  font-weight: 700;
+  font-size: 2rem;
+  margin: 0;
+  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.app-subtitle {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
 }
 
 .container {
@@ -1511,20 +1528,6 @@ td input:checked + .slider:before {
   scrollbar-color: var(--primary) var(--bg-secondary);
 }
 
-.ack-options {
-  margin-top: 1rem;
-  color: var(--text-color);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-.ack-options label {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.875rem;
-}
 
 .about-modal-body::-webkit-scrollbar {
   width: 8px;
@@ -1548,7 +1551,7 @@ td input:checked + .slider:before {
   font-size: 1.125rem;
   line-height: 1.7;
   color: var(--text-secondary);
-  margin-bottom: var(--spacing-xl);
+  margin: var(--spacing-xl) 0;
   text-align: center;
   padding: var(--spacing-lg);
   background: var(--bg-secondary);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## 📋 Version History
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
-- Added optional "Do not show this again" checkbox to disclaimer splash
+- Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox
 - Header branding can now automatically adapt to the hosting domain with
   configurable casing, optional TLD removal, and global override support
 

--- a/index.html
+++ b/index.html
@@ -66,7 +66,10 @@
   <body>
     <!-- Application Header -->
     <div class="app-header">
-      <h1>StackTrackr</h1>
+      <div class="app-title">
+        <h1>StackTrackr</h1>
+        <p class="app-subtitle">an open source precious metals tracking tool</p>
+      </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button
           class="btn"
@@ -1095,12 +1098,6 @@
               ✅ I Understand - Continue to Application
             </button>
           </div>
-          <div class="ack-options">
-            <label for="ackDontShow">
-              <input type="checkbox" id="ackDontShow" />
-              <span>Do not show this again</span>
-            </label>
-          </div>
           <div class="acceptance-text">
             By continuing, you acknowledge that you understand this tool stores
             data locally, you are responsible for backing up your data, and you
@@ -1126,6 +1123,51 @@
             <span id="aboutAppName">StackTrackr</span>
             <span id="aboutVersion"></span>
           </h2>
+          <div class="about-description">
+            Track your precious metal investments with comprehensive spot price
+            tracking, premium calculations, and detailed reporting. Add items to
+            your inventory, monitor current values across Silver, Gold,
+            Platinum, and Palladium, and export your data in multiple formats
+            including CSV, JSON, Excel, PDF, and HTML.
+          </div>
+
+          <div class="about-alert">
+            <div class="alert-header">
+              <span class="alert-icon">⚠️</span>
+              <strong>Important Privacy &amp; Data Notice</strong>
+            </div>
+            <div class="alert-content">
+              <p>
+                <strong>Your Privacy is Protected:</strong> All data is stored
+                locally in your browser using localStorage and
+                <em>never transmitted to any server</em>. Your precious metals
+                inventory information remains completely private and under your
+                control.
+              </p>
+
+              <p>
+                <strong>Data Backup Responsibility:</strong> Since data is
+                stored locally, it will be lost if you clear browser history,
+                reset browser data, or use private browsing mode. Remember to
+                export your data regularly to keep a copy.
+              </p>
+
+              <p>
+                <strong>Use at Your Own Risk:</strong> This tool is provided for
+                informational and organizational purposes only. The developer
+                assumes no responsibility for any financial decisions,
+                investment choices, or data loss. Always verify spot prices and
+                calculations independently.
+              </p>
+
+              <p>
+                <strong>Spot Price Accuracy:</strong> Prices displayed are for
+                reference only and may not reflect real-time market conditions.
+                Always confirm current pricing with your dealer or official
+                market sources before making transactions.
+              </p>
+            </div>
+          </div>
           <!-- Key Features -->
           <div class="about-features">
             <div class="features-title">✨ Key Features</div>

--- a/js/about.js
+++ b/js/about.js
@@ -49,12 +49,7 @@ const hideAckModal = () => {
  * Accepts the acknowledgment and hides the modal
  */
 const acceptAck = () => {
-  const dontShow = document.getElementById("ackDontShow");
-  if (dontShow && dontShow.checked) {
-    localStorage.setItem(ACK_DISMISSED_KEY, "1");
-  } else {
-    localStorage.removeItem(ACK_DISMISSED_KEY);
-  }
+  localStorage.setItem(ACK_DISMISSED_KEY, "1");
   hideAckModal();
 };
 

--- a/js/init.js
+++ b/js/init.js
@@ -105,7 +105,6 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.aboutModal = safeGetElement("aboutModal");
     elements.ackModal = safeGetElement("ackModal");
     elements.ackAcceptBtn = safeGetElement("ackAcceptBtn");
-    elements.ackDontShow = safeGetElement("ackDontShow");
     elements.editModal = safeGetElement("editModal");
     elements.editForm = safeGetElement("editForm");
     elements.cancelEditBtn = safeGetElement("cancelEdit");

--- a/js/state.js
+++ b/js/state.js
@@ -126,7 +126,6 @@ const elements = {
   aboutModal: null,
   ackModal: null,
   ackAcceptBtn: null,
-  ackDontShow: null,
 
   // Settings & API elements
   settingsBtn: null,


### PR DESCRIPTION
## Summary
- Auto-hide disclaimer splash after acknowledging; remove "Do not show again" checkbox
- Add splash description and privacy notice to About modal
- Introduce styled subtitle under main header title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689725a56680832eb1dc988ba26443e0