### PR TITLE
Fix provider key isolation and update subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     <div class="app-header">
       <div class="app-title">
         <h1>StackTrackr</h1>
-        <p class="app-subtitle">an open source precious metals tracking tool</p>
+        <p class="app-subtitle">The open source precious metals tracking tool.</p>
       </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button

--- a/js/api.js
+++ b/js/api.js
@@ -81,7 +81,8 @@ const loadApiConfig = () => {
       }
       const result = {
         provider: config.provider || "",
-        keys: config.keys || {},
+        // Clone keys object to prevent accidental cross-provider references
+        keys: { ...(config.keys || {}) },
         cacheHours:
           typeof config.cacheHours === "number" ? config.cacheHours : 24,
         customConfig: config.customConfig || {
@@ -144,7 +145,12 @@ const saveApiConfig = (config) => {
       }
     });
     localStorage.setItem(API_KEY_STORAGE_KEY, JSON.stringify(configToSave));
-    apiConfig = config;
+
+    // Store a cloned copy in memory to avoid shared references
+    apiConfig = {
+      ...config,
+      keys: { ...(config.keys || {}) },
+    };
     updateSyncButtonStates();
   } catch (error) {
     console.error("Error saving API config:", error);
@@ -957,6 +963,8 @@ const handleProviderSync = async (provider) => {
   }
 
   const config = loadApiConfig();
+  // Ensure keys object exists and clone to avoid mutating shared references
+  config.keys = { ...(config.keys || {}) };
   config.keys[provider] = apiKey;
   if (provider === "CUSTOM") {
     const base = document.getElementById("apiBase_CUSTOM")?.value.trim() || "";


### PR DESCRIPTION
## Summary
- Update app subtitle to "The open source precious metals tracking tool."
- Ensure each API provider stores its own key by cloning configuration objects before saving

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897298eb528832e93517f73b4964b05