### PR TITLE
docs: finalize v3.2.05 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
-- **v3.2.05rc - Splash Opt-Out**: Disclaimer modal now remembers acceptance automatically
+- **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal now hides after acknowledgment, header branding adapts to the hosting domain with an updated subtitle, and API providers store keys separately
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Rebranded to StackTrackr and prepared for final release
@@ -19,6 +19,8 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 
 ## 🆕 What's New in v3.2.05rc
 - Disclaimer splash hides permanently after you click "I Understand"
+- Header branding adapts to the hosting domain and subtitle now reads "The open source precious metals tracking tool."
+- Each API provider stores its own API key independently
 
 ## 🆕 What's New in v3.2.04rc
 - Negative prices in imported files now default to $0 instead of causing errors

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,8 +10,10 @@
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
 - Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox
-- Header branding can now automatically adapt to the hosting domain with
-  configurable casing, optional TLD removal, and global override support
+- Simplified acknowledgment layout with improved placement and styling
+- Header branding can now automatically adapt to the hosting domain with configurable casing, optional TLD removal, and global override support
+- App subtitle updated to "The open source precious metals tracking tool."
+- Fixed API key handling so each provider stores its own key independently
 
 ### Version 3.2.04rc – Import Negative Price Handling (2025-08-09)
 - Negative prices in CSV, JSON, and Excel imports now default to $0 instead of causing validation errors

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.1.x Series)
 
-- **v3.2.05rc - Splash Opt-Out**: Disclaimer modal can be hidden permanently
+- **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal can be hidden permanently, header adapts to hosting domain with updated subtitle, and each API provider stores its own key
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Application rebranded to StackTrackr and prepared for final release
 - **v3.2.01 - Cloud Sync Modal Fix**: Coming soon modal now follows themed styling with internal close button


### PR DESCRIPTION
## Summary
- document splash opt-out, branding updates, subtitle change, and API key isolation for v3.2.05rc
- mention separate key storage per provider in status and changelog
- highlight new branding and key handling in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68972ea6b7a8832e96829afa38a41904